### PR TITLE
Fixe build_arguments structures

### DIFF
--- a/crates/cli/src/modules/store.rs
+++ b/crates/cli/src/modules/store.rs
@@ -84,6 +84,9 @@ mod tests {
     use contracts::options::get_options_address;
     use contracts::sdk::taproot_pubkey_gen::get_random_seed;
     use simplicityhl::elements::AssetId;
+    use simplicityhl::elements::OutPoint;
+    use simplicityhl::elements::Txid;
+    use simplicityhl::elements::hashes::Hash;
     use simplicityhl_core::{
         Encodable, LIQUID_TESTNET_BITCOIN_ASSET, LIQUID_TESTNET_TEST_ASSET_ID_STR,
     };
@@ -103,16 +106,17 @@ mod tests {
         let settlement_asset_id =
             AssetId::from_slice(&hex::decode(LIQUID_TESTNET_TEST_ASSET_ID_STR)?)?;
 
-        let args = OptionsArguments {
-            start_time: 10,
-            expiry_time: 50,
-            collateral_per_contract: 100,
-            settlement_per_contract: 1000,
-            collateral_asset_id: LIQUID_TESTNET_BITCOIN_ASSET.into_inner().0,
-            settlement_asset_id: settlement_asset_id.into_inner().0,
-            option_token_entropy: get_random_seed(),
-            grantor_token_entropy: get_random_seed(),
-        };
+        let args = OptionsArguments::new(
+            10,
+            50,
+            100,
+            1000,
+            *LIQUID_TESTNET_BITCOIN_ASSET,
+            settlement_asset_id,
+            get_random_seed(),
+            OutPoint::new(Txid::from_slice(&[1; 32])?, 0),
+            OutPoint::new(Txid::from_slice(&[2; 32])?, 0),
+        );
 
         let options_taproot_pubkey_gen =
             TaprootPubkeyGen::from(&args, &AddressParams::LIQUID_TESTNET, &get_options_address)?;

--- a/crates/contracts/src/array_tr_storage/build_arguments.rs
+++ b/crates/contracts/src/array_tr_storage/build_arguments.rs
@@ -4,7 +4,27 @@ use simplicityhl::{Arguments, str::WitnessName, value::UIntValue};
 
 #[derive(Debug, Clone, bincode::Encode, bincode::Decode, PartialEq, Eq)]
 pub struct UnlimitedStorageArguments {
-    pub len: u16,
+    len: u16,
+}
+
+impl UnlimitedStorageArguments {
+    /// Create new unlimited storage arguments.
+    #[must_use]
+    pub const fn new(len: u16) -> Self {
+        Self { len }
+    }
+
+    /// Returns the length parameter.
+    #[must_use]
+    pub const fn len(&self) -> u16 {
+        self.len
+    }
+
+    /// Returns true if len is zero.
+    #[must_use]
+    pub const fn is_empty(&self) -> bool {
+        self.len == 0
+    }
 }
 
 /// Build Simplicity arguments for storage program.

--- a/crates/contracts/src/array_tr_storage/mod.rs
+++ b/crates/contracts/src/array_tr_storage/mod.rs
@@ -135,7 +135,7 @@ mod array_tr_storage_tests {
         let mut old_storage = [0u8; MAX_VAL];
         old_storage[3] = 0xff;
 
-        let array_tr_storage_arguments = UnlimitedStorageArguments { len: 5 };
+        let array_tr_storage_arguments = UnlimitedStorageArguments::new(5);
 
         let program = get_array_tr_storage_compiled_program(&array_tr_storage_arguments);
         let cmr = program.commit().cmr();
@@ -143,7 +143,7 @@ mod array_tr_storage_tests {
         let spend_info = unlimited_storage_taproot_spend_info(
             unlimited_storage_unspendable_internal_key(),
             &old_storage,
-            array_tr_storage_arguments.len as usize,
+            array_tr_storage_arguments.len() as usize,
             cmr,
         );
         let script_pubkey = Script::new_v1_p2tr_tweaked(spend_info.output_key());

--- a/crates/contracts/src/dual_currency_deposit/build_arguments.rs
+++ b/crates/contracts/src/dual_currency_deposit/build_arguments.rs
@@ -13,52 +13,150 @@ use crate::error::DCDRatioError;
 #[derive(Debug, Clone, bincode::Encode, bincode::Decode, PartialEq, Eq)]
 pub struct DCDArguments {
     // Time parameters
-    pub taker_funding_start_time: u32,
-    pub taker_funding_end_time: u32,
-    pub contract_expiry_time: u32,
-    pub early_termination_end_time: u32,
-    pub settlement_height: u32,
+    taker_funding_start_time: u32,
+    taker_funding_end_time: u32,
+    contract_expiry_time: u32,
+    early_termination_end_time: u32,
+    settlement_height: u32,
 
     // Pricing parameters
-    pub strike_price: u64,
-    pub incentive_basis_points: u64,
+    strike_price: u64,
+    incentive_basis_points: u64,
 
     // Asset IDs (hex LE strings)
-    pub collateral_asset_id_hex_le: String,
-    pub settlement_asset_id_hex_le: String,
-    pub filler_token_asset_id_hex_le: String,
-    pub grantor_collateral_token_asset_id_hex_le: String,
-    pub grantor_settlement_token_asset_id_hex_le: String,
+    collateral_asset_id_hex_le: String,
+    settlement_asset_id_hex_le: String,
+    filler_token_asset_id_hex_le: String,
+    grantor_collateral_token_asset_id_hex_le: String,
+    grantor_settlement_token_asset_id_hex_le: String,
 
     // Fee parameters
-    pub fee_basis_points: u64,
-    pub fee_script_hash_hex_le: String,
+    fee_basis_points: u64,
+    fee_script_hash_hex_le: String,
 
     // Ratio/denominator parameters
-    pub ratio_args: DCDRatioArguments,
+    ratio_args: DCDRatioArguments,
 
     // Oracle
-    pub oracle_public_key: String,
+    oracle_public_key: String,
 }
 
 #[derive(Debug, Clone, bincode::Encode, bincode::Decode, PartialEq, Eq, Default)]
 pub struct DCDRatioArguments {
-    pub principal_collateral_amount: u64,
-    pub interest_collateral_amount: u64,
-    pub total_collateral_amount: u64,
-    pub principal_asset_amount: u64,
-    pub interest_asset_amount: u64,
-    pub total_asset_amount: u64,
-    pub filler_token_amount: u64,
-    pub grantor_collateral_token_amount: u64,
-    pub grantor_settlement_token_amount: u64,
-    pub filler_per_settlement_collateral: u64,
-    pub filler_per_settlement_asset: u64,
-    pub filler_per_principal_collateral: u64,
-    pub grantor_settlement_per_deposited_asset: u64,
-    pub grantor_collateral_per_deposited_collateral: u64,
-    pub grantor_per_settlement_collateral: u64,
-    pub grantor_per_settlement_asset: u64,
+    principal_collateral_amount: u64,
+    interest_collateral_amount: u64,
+    total_collateral_amount: u64,
+    principal_asset_amount: u64,
+    interest_asset_amount: u64,
+    total_asset_amount: u64,
+    filler_token_amount: u64,
+    grantor_collateral_token_amount: u64,
+    grantor_settlement_token_amount: u64,
+    filler_per_settlement_collateral: u64,
+    filler_per_settlement_asset: u64,
+    filler_per_principal_collateral: u64,
+    grantor_settlement_per_deposited_asset: u64,
+    grantor_collateral_per_deposited_collateral: u64,
+    grantor_per_settlement_collateral: u64,
+    grantor_per_settlement_asset: u64,
+}
+
+impl DCDRatioArguments {
+    /// Returns the principal collateral amount.
+    #[must_use]
+    pub const fn principal_collateral_amount(&self) -> u64 {
+        self.principal_collateral_amount
+    }
+
+    /// Returns the interest collateral amount.
+    #[must_use]
+    pub const fn interest_collateral_amount(&self) -> u64 {
+        self.interest_collateral_amount
+    }
+
+    /// Returns the total collateral amount.
+    #[must_use]
+    pub const fn total_collateral_amount(&self) -> u64 {
+        self.total_collateral_amount
+    }
+
+    /// Returns the principal asset amount.
+    #[must_use]
+    pub const fn principal_asset_amount(&self) -> u64 {
+        self.principal_asset_amount
+    }
+
+    /// Returns the interest asset amount.
+    #[must_use]
+    pub const fn interest_asset_amount(&self) -> u64 {
+        self.interest_asset_amount
+    }
+
+    /// Returns the total asset amount.
+    #[must_use]
+    pub const fn total_asset_amount(&self) -> u64 {
+        self.total_asset_amount
+    }
+
+    /// Returns the filler token amount.
+    #[must_use]
+    pub const fn filler_token_amount(&self) -> u64 {
+        self.filler_token_amount
+    }
+
+    /// Returns the grantor collateral token amount.
+    #[must_use]
+    pub const fn grantor_collateral_token_amount(&self) -> u64 {
+        self.grantor_collateral_token_amount
+    }
+
+    /// Returns the grantor settlement token amount.
+    #[must_use]
+    pub const fn grantor_settlement_token_amount(&self) -> u64 {
+        self.grantor_settlement_token_amount
+    }
+
+    /// Returns the filler per settlement collateral ratio.
+    #[must_use]
+    pub const fn filler_per_settlement_collateral(&self) -> u64 {
+        self.filler_per_settlement_collateral
+    }
+
+    /// Returns the filler per settlement asset ratio.
+    #[must_use]
+    pub const fn filler_per_settlement_asset(&self) -> u64 {
+        self.filler_per_settlement_asset
+    }
+
+    /// Returns the filler per principal collateral ratio.
+    #[must_use]
+    pub const fn filler_per_principal_collateral(&self) -> u64 {
+        self.filler_per_principal_collateral
+    }
+
+    /// Returns the grantor settlement per deposited asset ratio.
+    #[must_use]
+    pub const fn grantor_settlement_per_deposited_asset(&self) -> u64 {
+        self.grantor_settlement_per_deposited_asset
+    }
+
+    /// Returns the grantor collateral per deposited collateral ratio.
+    #[must_use]
+    pub const fn grantor_collateral_per_deposited_collateral(&self) -> u64 {
+        self.grantor_collateral_per_deposited_collateral
+    }
+
+    /// Returns the grantor per settlement collateral ratio.
+    #[must_use]
+    pub const fn grantor_per_settlement_collateral(&self) -> u64 {
+        self.grantor_per_settlement_collateral
+    }
+
+    /// Returns the grantor per settlement asset ratio.
+    #[must_use]
+    pub const fn grantor_per_settlement_asset(&self) -> u64 {
+        self.grantor_per_settlement_asset
+    }
 }
 
 pub const MAX_BASIS_POINTS: u64 = 10000;
@@ -273,6 +371,59 @@ impl Default for DCDArguments {
 }
 
 impl DCDArguments {
+    /// Create new DCD arguments.
+    #[allow(clippy::too_many_arguments)]
+    #[must_use]
+    pub const fn new(
+        taker_funding_start_time: u32,
+        taker_funding_end_time: u32,
+        contract_expiry_time: u32,
+        early_termination_end_time: u32,
+        settlement_height: u32,
+        strike_price: u64,
+        incentive_basis_points: u64,
+        fee_basis_points: u64,
+        collateral_asset_id_hex_le: String,
+        settlement_asset_id_hex_le: String,
+        filler_token_asset_id_hex_le: String,
+        grantor_collateral_token_asset_id_hex_le: String,
+        grantor_settlement_token_asset_id_hex_le: String,
+        ratio_args: DCDRatioArguments,
+        oracle_public_key: String,
+        fee_script_hash_hex_le: String,
+    ) -> Self {
+        Self {
+            taker_funding_start_time,
+            taker_funding_end_time,
+            contract_expiry_time,
+            early_termination_end_time,
+            settlement_height,
+            strike_price,
+            incentive_basis_points,
+            collateral_asset_id_hex_le,
+            settlement_asset_id_hex_le,
+            filler_token_asset_id_hex_le,
+            grantor_collateral_token_asset_id_hex_le,
+            grantor_settlement_token_asset_id_hex_le,
+            fee_basis_points,
+            fee_script_hash_hex_le,
+            ratio_args,
+            oracle_public_key,
+        }
+    }
+
+    /// Returns the taker funding start time.
+    #[must_use]
+    pub const fn taker_funding_start_time(&self) -> u32 {
+        self.taker_funding_start_time
+    }
+
+    /// Returns the early termination end time.
+    #[must_use]
+    pub const fn early_termination_end_time(&self) -> u32 {
+        self.early_termination_end_time
+    }
+
     /// Convert to Simplicity program arguments.
     ///
     /// # Panics
@@ -353,43 +504,44 @@ impl DCDArguments {
             (
                 WitnessName::from_str_unchecked("FILLER_PER_SETTLEMENT_COLLATERAL"),
                 simplicityhl::Value::from(UIntValue::U64(
-                    self.ratio_args.filler_per_settlement_collateral,
+                    self.ratio_args.filler_per_settlement_collateral(),
                 )),
             ),
             (
                 WitnessName::from_str_unchecked("FILLER_PER_SETTLEMENT_ASSET"),
                 simplicityhl::Value::from(UIntValue::U64(
-                    self.ratio_args.filler_per_settlement_asset,
+                    self.ratio_args.filler_per_settlement_asset(),
                 )),
             ),
             (
                 WitnessName::from_str_unchecked("FILLER_PER_PRINCIPAL_COLLATERAL"),
                 simplicityhl::Value::from(UIntValue::U64(
-                    self.ratio_args.filler_per_principal_collateral,
+                    self.ratio_args.filler_per_principal_collateral(),
                 )),
             ),
             (
                 WitnessName::from_str_unchecked("GRANTOR_SETTLEMENT_PER_DEPOSITED_ASSET"),
                 simplicityhl::Value::from(UIntValue::U64(
-                    self.ratio_args.grantor_settlement_per_deposited_asset,
+                    self.ratio_args.grantor_settlement_per_deposited_asset(),
                 )),
             ),
             (
                 WitnessName::from_str_unchecked("GRANTOR_COLLATERAL_PER_DEPOSITED_COLLATERAL"),
                 simplicityhl::Value::from(UIntValue::U64(
-                    self.ratio_args.grantor_collateral_per_deposited_collateral,
+                    self.ratio_args
+                        .grantor_collateral_per_deposited_collateral(),
                 )),
             ),
             (
                 WitnessName::from_str_unchecked("GRANTOR_PER_SETTLEMENT_COLLATERAL"),
                 simplicityhl::Value::from(UIntValue::U64(
-                    self.ratio_args.grantor_per_settlement_collateral,
+                    self.ratio_args.grantor_per_settlement_collateral(),
                 )),
             ),
             (
                 WitnessName::from_str_unchecked("GRANTOR_PER_SETTLEMENT_ASSET"),
                 simplicityhl::Value::from(UIntValue::U64(
-                    self.ratio_args.grantor_per_settlement_asset,
+                    self.ratio_args.grantor_per_settlement_asset(),
                 )),
             ),
             (

--- a/crates/contracts/src/dual_currency_deposit/mod.rs
+++ b/crates/contracts/src/dual_currency_deposit/mod.rs
@@ -237,24 +237,24 @@ mod dcd_merge_tests {
         let ratio_args =
             DCDRatioArguments::build_from(1000, incentive_basis_points, strike_price, 10)?;
 
-        let dcd_arguments = DCDArguments {
-            taker_funding_start_time: 10,
-            taker_funding_end_time: 0,
-            contract_expiry_time: 0,
-            early_termination_end_time: 0,
-            settlement_height: 0,
+        let dcd_arguments = DCDArguments::new(
+            10,
+            0,
+            0,
+            0,
+            0,
             strike_price,
             incentive_basis_points,
-            fee_basis_points: 0,
-            collateral_asset_id_hex_le: LIQUID_TESTNET_BITCOIN_ASSET.to_string(),
-            settlement_asset_id_hex_le: LIQUID_TESTNET_TEST_ASSET_ID_STR.to_string(),
-            filler_token_asset_id_hex_le: first_asset_id.to_string(),
-            grantor_collateral_token_asset_id_hex_le: second_asset_id.to_string(),
-            grantor_settlement_token_asset_id_hex_le: third_asset_id.to_string(),
-            ratio_args: ratio_args.clone(),
-            oracle_public_key: oracle_kp.x_only_public_key().0.to_string(),
-            fee_script_hash_hex_le: "00".repeat(32),
-        };
+            0,
+            LIQUID_TESTNET_BITCOIN_ASSET.to_string(),
+            LIQUID_TESTNET_TEST_ASSET_ID_STR.to_string(),
+            first_asset_id.to_string(),
+            second_asset_id.to_string(),
+            third_asset_id.to_string(),
+            ratio_args.clone(),
+            oracle_kp.x_only_public_key().0.to_string(),
+            "00".repeat(32),
+        );
 
         let keypair = Keypair::from_secret_key(
             &Secp256k1::new(),
@@ -269,17 +269,17 @@ mod dcd_merge_tests {
         let mut pst = PartiallySignedTransaction::new_v2();
 
         let mut first_reissuance_tx = Input::from_prevout(outpoint);
-        first_reissuance_tx.issuance_value_amount = Some(ratio_args.filler_token_amount);
+        first_reissuance_tx.issuance_value_amount = Some(ratio_args.filler_token_amount());
         first_reissuance_tx.issuance_inflation_keys = None;
         first_reissuance_tx.issuance_asset_entropy = Some(first_asset_entropy.to_byte_array());
 
         let mut second_reissuance_tx = Input::from_prevout(outpoint);
-        second_reissuance_tx.issuance_value_amount = Some(ratio_args.filler_token_amount);
+        second_reissuance_tx.issuance_value_amount = Some(ratio_args.filler_token_amount());
         second_reissuance_tx.issuance_inflation_keys = None;
         second_reissuance_tx.issuance_asset_entropy = Some(second_asset_entropy.to_byte_array());
 
         let mut third_reissuance_tx = Input::from_prevout(outpoint);
-        third_reissuance_tx.issuance_value_amount = Some(ratio_args.filler_token_amount);
+        third_reissuance_tx.issuance_value_amount = Some(ratio_args.filler_token_amount());
         third_reissuance_tx.issuance_inflation_keys = None;
         third_reissuance_tx.issuance_asset_entropy = Some(third_asset_entropy.to_byte_array());
 
@@ -312,35 +312,35 @@ mod dcd_merge_tests {
 
         pst.add_output(Output::new_explicit(
             dcd_address.script_pubkey(),
-            ratio_args.interest_collateral_amount,
+            ratio_args.interest_collateral_amount(),
             *LIQUID_TESTNET_BITCOIN_ASSET,
             None,
         ));
 
         pst.add_output(Output::new_explicit(
             dcd_address.script_pubkey(),
-            ratio_args.total_asset_amount,
+            ratio_args.total_asset_amount(),
             AssetId::from_str(LIQUID_TESTNET_TEST_ASSET_ID_STR)?,
             None,
         ));
 
         pst.add_output(Output::new_explicit(
             dcd_address.script_pubkey(),
-            ratio_args.filler_token_amount,
+            ratio_args.filler_token_amount(),
             first_asset_id,
             None,
         ));
 
         pst.add_output(Output::new_explicit(
             Script::new(),
-            ratio_args.filler_token_amount,
+            ratio_args.filler_token_amount(),
             second_asset_id,
             None,
         ));
 
         pst.add_output(Output::new_explicit(
             Script::new(),
-            ratio_args.filler_token_amount,
+            ratio_args.filler_token_amount(),
             third_asset_id,
             None,
         ));
@@ -395,13 +395,13 @@ mod dcd_merge_tests {
                     asset: Asset::Explicit(
                         AssetId::from_str(LIQUID_TESTNET_TEST_ASSET_ID_STR).unwrap(),
                     ),
-                    value: Value::Explicit(ratio_args.total_asset_amount),
+                    value: Value::Explicit(ratio_args.total_asset_amount()),
                 },
                 // Input 4: collateral asset
                 ElementsUtxo {
                     script_pubkey: dcd_address.script_pubkey(),
                     asset: Asset::Explicit(*LIQUID_TESTNET_BITCOIN_ASSET),
-                    value: Value::Explicit(ratio_args.interest_collateral_amount),
+                    value: Value::Explicit(ratio_args.interest_collateral_amount()),
                 },
             ],
             0,
@@ -414,10 +414,10 @@ mod dcd_merge_tests {
         let witness_values = build_dcd_witness(
             TokenBranch::default(),
             &DcdBranch::MakerFunding {
-                principal_collateral_amount: ratio_args.principal_collateral_amount,
-                principal_asset_amount: ratio_args.principal_asset_amount,
-                interest_collateral_amount: ratio_args.interest_collateral_amount,
-                interest_asset_amount: ratio_args.interest_asset_amount,
+                principal_collateral_amount: ratio_args.principal_collateral_amount(),
+                principal_asset_amount: ratio_args.principal_asset_amount(),
+                interest_collateral_amount: ratio_args.interest_collateral_amount(),
+                interest_asset_amount: ratio_args.interest_asset_amount(),
             },
             MergeBranch::default(),
         );
@@ -454,24 +454,24 @@ mod dcd_merge_tests {
         let ratio_args =
             DCDRatioArguments::build_from(1000, incentive_basis_points, strike_price, 10)?;
 
-        let dcd_arguments = DCDArguments {
-            taker_funding_start_time: now + 10,
-            taker_funding_end_time: now + 20,
-            contract_expiry_time: now + 30,
-            early_termination_end_time: now,
-            settlement_height: 0,
+        let dcd_arguments = DCDArguments::new(
+            now + 10,
+            now + 20,
+            now + 30,
+            now,
+            0,
             strike_price,
             incentive_basis_points,
-            fee_basis_points: 0,
-            collateral_asset_id_hex_le: AssetId::LIQUID_BTC.to_string(),
-            settlement_asset_id_hex_le: LIQUID_TESTNET_TEST_ASSET_ID_STR.to_string(),
-            filler_token_asset_id_hex_le: first_asset_id.to_string(),
-            grantor_collateral_token_asset_id_hex_le: second_asset_id.to_string(),
-            grantor_settlement_token_asset_id_hex_le: third_asset_id.to_string(),
-            ratio_args: ratio_args.clone(),
-            oracle_public_key: oracle_kp.x_only_public_key().0.to_string(),
-            fee_script_hash_hex_le: "00".repeat(32),
-        };
+            0,
+            AssetId::LIQUID_BTC.to_string(),
+            LIQUID_TESTNET_TEST_ASSET_ID_STR.to_string(),
+            first_asset_id.to_string(),
+            second_asset_id.to_string(),
+            third_asset_id.to_string(),
+            ratio_args.clone(),
+            oracle_kp.x_only_public_key().0.to_string(),
+            "00".repeat(32),
+        );
 
         let keypair = Keypair::from_secret_key(
             &Secp256k1::new(),
@@ -486,7 +486,7 @@ mod dcd_merge_tests {
         let mut pst = PartiallySignedTransaction::new_v2();
         // Locktime window: start <= t < end and t < expiry
         pst.global.tx_data.fallback_locktime = Some(elements::LockTime::from_time(
-            dcd_arguments.taker_funding_start_time + 5,
+            dcd_arguments.taker_funding_start_time() + 5,
         )?);
 
         // Input[0]: FILLER token input that will provide change
@@ -495,8 +495,8 @@ mod dcd_merge_tests {
 
         // Outputs:
         // 0: FILLER change (available - to_get)
-        let available_filler = ratio_args.filler_token_amount * 2; // 200
-        let filler_to_get = ratio_args.filler_token_amount; // 100
+        let available_filler = ratio_args.filler_token_amount() * 2; // 200
+        let filler_to_get = ratio_args.filler_token_amount(); // 100
         let filler_change = available_filler - filler_to_get; // 100
         pst.add_output(Output::new_explicit(
             dcd_address.script_pubkey(),
@@ -506,7 +506,7 @@ mod dcd_merge_tests {
         ));
 
         // 1: Collateral to covenant (deposit)
-        let collateral_deposit = ratio_args.filler_per_principal_collateral * filler_to_get; // 1000
+        let collateral_deposit = ratio_args.filler_per_principal_collateral() * filler_to_get; // 1000
         pst.add_output(Output::new_explicit(
             dcd_address.script_pubkey(),
             collateral_deposit,
@@ -580,24 +580,24 @@ mod dcd_merge_tests {
         let ratio_args =
             DCDRatioArguments::build_from(1000, incentive_basis_points, strike_price, 10)?;
 
-        let dcd_arguments = DCDArguments {
-            taker_funding_start_time: now,
-            taker_funding_end_time: now,
-            contract_expiry_time: now + 30,
-            early_termination_end_time: now + 20,
-            settlement_height: 0,
+        let dcd_arguments = DCDArguments::new(
+            now,
+            now,
+            now + 30,
+            now + 20,
+            0,
             strike_price,
             incentive_basis_points,
-            fee_basis_points: 0,
-            collateral_asset_id_hex_le: AssetId::LIQUID_BTC.to_string(),
-            settlement_asset_id_hex_le: LIQUID_TESTNET_TEST_ASSET_ID_STR.to_string(),
-            filler_token_asset_id_hex_le: first_asset_id.to_string(),
-            grantor_collateral_token_asset_id_hex_le: second_asset_id.to_string(),
-            grantor_settlement_token_asset_id_hex_le: third_asset_id.to_string(),
-            ratio_args: ratio_args.clone(),
-            oracle_public_key: oracle_kp.x_only_public_key().0.to_string(),
-            fee_script_hash_hex_le: "00".repeat(32),
-        };
+            0,
+            AssetId::LIQUID_BTC.to_string(),
+            LIQUID_TESTNET_TEST_ASSET_ID_STR.to_string(),
+            first_asset_id.to_string(),
+            second_asset_id.to_string(),
+            third_asset_id.to_string(),
+            ratio_args.clone(),
+            oracle_kp.x_only_public_key().0.to_string(),
+            "00".repeat(32),
+        );
 
         let keypair = Keypair::from_secret_key(
             &Secp256k1::new(),
@@ -612,7 +612,7 @@ mod dcd_merge_tests {
         let mut pst = PartiallySignedTransaction::new_v2();
         // Locktime t <= early_term_end
         pst.global.tx_data.fallback_locktime = Some(elements::LockTime::from_time(
-            dcd_arguments.early_termination_end_time - 5,
+            dcd_arguments.early_termination_end_time() - 5,
         )?);
 
         // Inputs: 0 -> collateral, 1 -> filler token
@@ -620,8 +620,8 @@ mod dcd_merge_tests {
         pst.inputs_mut()[0].sequence = Some(elements::Sequence::ENABLE_LOCKTIME_NO_RBF);
         pst.add_input(Input::from_prevout(outpoint));
 
-        let collateral_get = ratio_args.principal_collateral_amount; // 1000
-        let filler_return = ratio_args.filler_token_amount; // 100
+        let collateral_get = ratio_args.principal_collateral_amount(); // 1000
+        let filler_return = ratio_args.filler_token_amount(); // 100
         let available_collateral = collateral_get + 500; // to force change
         let collateral_change = available_collateral - collateral_get; // 500
 
@@ -712,24 +712,24 @@ mod dcd_merge_tests {
         let ratio_args =
             DCDRatioArguments::build_from(1000, incentive_basis_points, strike_price, 10)?;
 
-        let dcd_arguments = DCDArguments {
-            taker_funding_start_time: now,
-            taker_funding_end_time: now,
-            contract_expiry_time: now + 30,
-            early_termination_end_time: now + 20,
-            settlement_height: 0,
+        let dcd_arguments = DCDArguments::new(
+            now,
+            now,
+            now + 30,
+            now + 20,
+            0,
             strike_price,
             incentive_basis_points,
-            fee_basis_points: 0,
-            collateral_asset_id_hex_le: AssetId::LIQUID_BTC.to_string(),
-            settlement_asset_id_hex_le: LIQUID_TESTNET_TEST_ASSET_ID_STR.to_string(),
-            filler_token_asset_id_hex_le: first_asset_id.to_string(),
-            grantor_collateral_token_asset_id_hex_le: second_asset_id.to_string(),
-            grantor_settlement_token_asset_id_hex_le: third_asset_id.to_string(),
-            ratio_args: ratio_args.clone(),
-            oracle_public_key: oracle_kp.x_only_public_key().0.to_string(),
-            fee_script_hash_hex_le: "00".repeat(32),
-        };
+            0,
+            AssetId::LIQUID_BTC.to_string(),
+            LIQUID_TESTNET_TEST_ASSET_ID_STR.to_string(),
+            first_asset_id.to_string(),
+            second_asset_id.to_string(),
+            third_asset_id.to_string(),
+            ratio_args.clone(),
+            oracle_kp.x_only_public_key().0.to_string(),
+            "00".repeat(32),
+        );
 
         let keypair = Keypair::from_secret_key(
             &Secp256k1::new(),
@@ -743,7 +743,7 @@ mod dcd_merge_tests {
 
         let mut pst = PartiallySignedTransaction::new_v2();
         pst.global.tx_data.fallback_locktime = Some(elements::LockTime::from_time(
-            dcd_arguments.early_termination_end_time - 1,
+            dcd_arguments.early_termination_end_time() - 1,
         )?);
 
         // Inputs: 0 -> collateral, 1 -> grantor collateral token
@@ -751,9 +751,9 @@ mod dcd_merge_tests {
         pst.inputs_mut()[0].sequence = Some(elements::Sequence::ENABLE_LOCKTIME_NO_RBF);
         pst.add_input(Input::from_prevout(outpoint));
 
-        let grantor_burn = ratio_args.filler_token_amount / 2; // 50
-        let collateral_get = ratio_args.interest_collateral_amount / 2; // 1000
-        let collateral_change = ratio_args.interest_collateral_amount - collateral_get;
+        let grantor_burn = ratio_args.filler_token_amount() / 2; // 50
+        let collateral_get = ratio_args.interest_collateral_amount() / 2; // 1000
+        let collateral_change = ratio_args.interest_collateral_amount() - collateral_get;
 
         // 0: collateral change
         pst.add_output(Output::new_explicit(
@@ -785,7 +785,7 @@ mod dcd_merge_tests {
                 ElementsUtxo {
                     script_pubkey: dcd_address.script_pubkey(),
                     asset: Asset::Explicit(*LIQUID_TESTNET_BITCOIN_ASSET),
-                    value: Value::Explicit(ratio_args.interest_collateral_amount),
+                    value: Value::Explicit(ratio_args.interest_collateral_amount()),
                 },
                 ElementsUtxo {
                     script_pubkey: dcd_address.script_pubkey(),
@@ -842,24 +842,24 @@ mod dcd_merge_tests {
         let ratio_args =
             DCDRatioArguments::build_from(1000, incentive_basis_points, strike_price, 10)?;
 
-        let dcd_arguments = DCDArguments {
-            taker_funding_start_time: now,
-            taker_funding_end_time: now,
-            contract_expiry_time: now + 30,
-            early_termination_end_time: now + 20,
-            settlement_height: 0,
+        let dcd_arguments = DCDArguments::new(
+            now,
+            now,
+            now + 30,
+            now + 20,
+            0,
             strike_price,
             incentive_basis_points,
-            fee_basis_points: 0,
-            collateral_asset_id_hex_le: AssetId::LIQUID_BTC.to_string(),
-            settlement_asset_id_hex_le: LIQUID_TESTNET_TEST_ASSET_ID_STR.to_string(),
-            filler_token_asset_id_hex_le: first_asset_id.to_string(),
-            grantor_collateral_token_asset_id_hex_le: second_asset_id.to_string(),
-            grantor_settlement_token_asset_id_hex_le: third_asset_id.to_string(),
-            ratio_args: ratio_args.clone(),
-            oracle_public_key: oracle_kp.x_only_public_key().0.to_string(),
-            fee_script_hash_hex_le: "00".repeat(32),
-        };
+            0,
+            AssetId::LIQUID_BTC.to_string(),
+            LIQUID_TESTNET_TEST_ASSET_ID_STR.to_string(),
+            first_asset_id.to_string(),
+            second_asset_id.to_string(),
+            third_asset_id.to_string(),
+            ratio_args.clone(),
+            oracle_kp.x_only_public_key().0.to_string(),
+            "00".repeat(32),
+        );
 
         let keypair = Keypair::from_secret_key(
             &Secp256k1::new(),
@@ -873,7 +873,7 @@ mod dcd_merge_tests {
 
         let mut pst = PartiallySignedTransaction::new_v2();
         pst.global.tx_data.fallback_locktime = Some(elements::LockTime::from_time(
-            dcd_arguments.early_termination_end_time - 1,
+            dcd_arguments.early_termination_end_time() - 1,
         )?);
 
         // Inputs: 0 -> settlement asset, 1 -> grantor settlement token
@@ -881,9 +881,9 @@ mod dcd_merge_tests {
         pst.inputs_mut()[0].sequence = Some(elements::Sequence::ENABLE_LOCKTIME_NO_RBF);
         pst.add_input(Input::from_prevout(outpoint));
 
-        let grantor_burn = ratio_args.filler_token_amount / 2; // 100
-        let settlement_get = ratio_args.total_asset_amount / 2; // 11000
-        let settlement_change = ratio_args.total_asset_amount - settlement_get;
+        let grantor_burn = ratio_args.filler_token_amount() / 2; // 100
+        let settlement_get = ratio_args.total_asset_amount() / 2; // 11000
+        let settlement_change = ratio_args.total_asset_amount() - settlement_get;
 
         // 0: settlement change
         pst.add_output(Output::new_explicit(
@@ -915,7 +915,7 @@ mod dcd_merge_tests {
                 ElementsUtxo {
                     script_pubkey: dcd_address.script_pubkey(),
                     asset: Asset::Explicit(AssetId::from_str(LIQUID_TESTNET_TEST_ASSET_ID_STR)?),
-                    value: Value::Explicit(ratio_args.total_asset_amount),
+                    value: Value::Explicit(ratio_args.total_asset_amount()),
                 },
                 ElementsUtxo {
                     script_pubkey: dcd_address.script_pubkey(),
@@ -973,24 +973,24 @@ mod dcd_merge_tests {
             DCDRatioArguments::build_from(1000, incentive_basis_points, strike_price, 10)?;
 
         let settlement_height = 100u32;
-        let dcd_arguments = DCDArguments {
-            taker_funding_start_time: now,
-            taker_funding_end_time: now,
-            contract_expiry_time: now,
-            early_termination_end_time: now,
+        let dcd_arguments = DCDArguments::new(
+            now,
+            now,
+            now,
+            now,
             settlement_height,
             strike_price,
             incentive_basis_points,
-            fee_basis_points: 0,
-            collateral_asset_id_hex_le: AssetId::LIQUID_BTC.to_string(),
-            settlement_asset_id_hex_le: LIQUID_TESTNET_TEST_ASSET_ID_STR.to_string(),
-            filler_token_asset_id_hex_le: first_asset_id.to_string(),
-            grantor_collateral_token_asset_id_hex_le: second_asset_id.to_string(),
-            grantor_settlement_token_asset_id_hex_le: third_asset_id.to_string(),
-            ratio_args: ratio_args.clone(),
-            oracle_public_key: oracle_kp.x_only_public_key().0.to_string(),
-            fee_script_hash_hex_le: "00".repeat(32),
-        };
+            0,
+            AssetId::LIQUID_BTC.to_string(),
+            LIQUID_TESTNET_TEST_ASSET_ID_STR.to_string(),
+            first_asset_id.to_string(),
+            second_asset_id.to_string(),
+            third_asset_id.to_string(),
+            ratio_args.clone(),
+            oracle_kp.x_only_public_key().0.to_string(),
+            "00".repeat(32),
+        );
 
         let keypair = Keypair::from_secret_key(
             &Secp256k1::new(),
@@ -1010,9 +1010,9 @@ mod dcd_merge_tests {
         pst.inputs_mut()[0].sequence = Some(elements::Sequence::ENABLE_LOCKTIME_NO_RBF);
 
         // Maker gets ALT branch (price <= strike): input is SETTLEMENT asset
-        let amount_to_get = ratio_args.total_asset_amount / 2; // 11000
-        let grantor_burn = ratio_args.filler_token_amount / 2; // 100
-        let available_settlement = ratio_args.total_asset_amount;
+        let amount_to_get = ratio_args.total_asset_amount() / 2; // 11000
+        let grantor_burn = ratio_args.filler_token_amount() / 2; // 100
+        let available_settlement = ratio_args.total_asset_amount();
 
         // 0: settlement change
         pst.add_output(Output::new_explicit(
@@ -1112,24 +1112,24 @@ mod dcd_merge_tests {
             DCDRatioArguments::build_from(1000, incentive_basis_points, strike_price, 10)?;
 
         let settlement_height = 100u32;
-        let dcd_arguments = DCDArguments {
-            taker_funding_start_time: now,
-            taker_funding_end_time: now,
-            contract_expiry_time: now,
-            early_termination_end_time: now,
+        let dcd_arguments = DCDArguments::new(
+            now,
+            now,
+            now,
+            now,
             settlement_height,
             strike_price,
             incentive_basis_points,
-            fee_basis_points: 0,
-            collateral_asset_id_hex_le: AssetId::LIQUID_BTC.to_string(),
-            settlement_asset_id_hex_le: LIQUID_TESTNET_TEST_ASSET_ID_STR.to_string(),
-            filler_token_asset_id_hex_le: first_asset_id.to_string(),
-            grantor_collateral_token_asset_id_hex_le: second_asset_id.to_string(),
-            grantor_settlement_token_asset_id_hex_le: third_asset_id.to_string(),
-            ratio_args: ratio_args.clone(),
-            oracle_public_key: oracle_kp.x_only_public_key().0.to_string(),
-            fee_script_hash_hex_le: "00".repeat(32),
-        };
+            0,
+            AssetId::LIQUID_BTC.to_string(),
+            LIQUID_TESTNET_TEST_ASSET_ID_STR.to_string(),
+            first_asset_id.to_string(),
+            second_asset_id.to_string(),
+            third_asset_id.to_string(),
+            ratio_args.clone(),
+            oracle_kp.x_only_public_key().0.to_string(),
+            "00".repeat(32),
+        );
 
         let keypair = Keypair::from_secret_key(
             &Secp256k1::new(),
@@ -1149,9 +1149,9 @@ mod dcd_merge_tests {
         pst.inputs_mut()[0].sequence = Some(elements::Sequence::ENABLE_LOCKTIME_NO_RBF);
 
         // Maker gets LBTC branch (price > strike): input is COLLATERAL
-        let amount_to_get = ratio_args.total_collateral_amount / 2; // 1100
-        let grantor_burn = ratio_args.filler_token_amount / 2; // 100
-        let available_collateral = ratio_args.total_collateral_amount;
+        let amount_to_get = ratio_args.total_collateral_amount() / 2; // 1100
+        let grantor_burn = ratio_args.filler_token_amount() / 2; // 100
+        let available_collateral = ratio_args.total_collateral_amount();
 
         // 0: collateral change
         pst.add_output(Output::new_explicit(
@@ -1251,24 +1251,24 @@ mod dcd_merge_tests {
             DCDRatioArguments::build_from(1000, incentive_basis_points, strike_price, 10)?;
 
         let settlement_height = 100u32;
-        let dcd_arguments = DCDArguments {
-            taker_funding_start_time: now,
-            taker_funding_end_time: now,
-            contract_expiry_time: now,
-            early_termination_end_time: now,
+        let dcd_arguments = DCDArguments::new(
+            now,
+            now,
+            now,
+            now,
             settlement_height,
             strike_price,
             incentive_basis_points,
-            fee_basis_points: 0,
-            collateral_asset_id_hex_le: AssetId::LIQUID_BTC.to_string(),
-            settlement_asset_id_hex_le: LIQUID_TESTNET_TEST_ASSET_ID_STR.to_string(),
-            filler_token_asset_id_hex_le: first_asset_id.to_string(),
-            grantor_collateral_token_asset_id_hex_le: second_asset_id.to_string(),
-            grantor_settlement_token_asset_id_hex_le: third_asset_id.to_string(),
-            ratio_args: ratio_args.clone(),
-            oracle_public_key: oracle_kp.x_only_public_key().0.to_string(),
-            fee_script_hash_hex_le: "00".repeat(32),
-        };
+            0,
+            AssetId::LIQUID_BTC.to_string(),
+            LIQUID_TESTNET_TEST_ASSET_ID_STR.to_string(),
+            first_asset_id.to_string(),
+            second_asset_id.to_string(),
+            third_asset_id.to_string(),
+            ratio_args.clone(),
+            oracle_kp.x_only_public_key().0.to_string(),
+            "00".repeat(32),
+        );
 
         let keypair = Keypair::from_secret_key(
             &Secp256k1::new(),
@@ -1287,9 +1287,9 @@ mod dcd_merge_tests {
         pst.inputs_mut()[0].sequence = Some(elements::Sequence::ENABLE_LOCKTIME_NO_RBF);
 
         // Taker receives LBTC (price <= strike): input is COLLATERAL
-        let amount_to_get = ratio_args.total_collateral_amount / 2; // 1100
-        let filler_burn = ratio_args.filler_token_amount / 2; // 100
-        let available_collateral = ratio_args.total_collateral_amount;
+        let amount_to_get = ratio_args.total_collateral_amount() / 2; // 1100
+        let filler_burn = ratio_args.filler_token_amount() / 2; // 100
+        let available_collateral = ratio_args.total_collateral_amount();
 
         // 0: collateral change
         pst.add_output(Output::new_explicit(
@@ -1391,24 +1391,24 @@ mod dcd_merge_tests {
         fee_script_hash.reverse();
 
         let settlement_height = 100u32;
-        let dcd_arguments = DCDArguments {
-            taker_funding_start_time: now,
-            taker_funding_end_time: now,
-            contract_expiry_time: now,
-            early_termination_end_time: now,
+        let dcd_arguments = DCDArguments::new(
+            now,
+            now,
+            now,
+            now,
             settlement_height,
             strike_price,
             incentive_basis_points,
             fee_basis_points,
-            collateral_asset_id_hex_le: AssetId::LIQUID_BTC.to_string(),
-            settlement_asset_id_hex_le: LIQUID_TESTNET_TEST_ASSET_ID_STR.to_string(),
-            filler_token_asset_id_hex_le: first_asset_id.to_string(),
-            grantor_collateral_token_asset_id_hex_le: second_asset_id.to_string(),
-            grantor_settlement_token_asset_id_hex_le: third_asset_id.to_string(),
-            ratio_args: ratio_args.clone(),
-            oracle_public_key: oracle_kp.x_only_public_key().0.to_string(),
-            fee_script_hash_hex_le: hex::encode(fee_script_hash),
-        };
+            AssetId::LIQUID_BTC.to_string(),
+            LIQUID_TESTNET_TEST_ASSET_ID_STR.to_string(),
+            first_asset_id.to_string(),
+            second_asset_id.to_string(),
+            third_asset_id.to_string(),
+            ratio_args.clone(),
+            oracle_kp.x_only_public_key().0.to_string(),
+            hex::encode(fee_script_hash),
+        );
 
         let keypair = Keypair::from_secret_key(
             &Secp256k1::new(),
@@ -1420,8 +1420,8 @@ mod dcd_merge_tests {
             &AddressParams::LIQUID_TESTNET,
         )?;
 
-        let amount_to_get = ratio_args.total_collateral_amount;
-        let filler_burn = ratio_args.filler_token_amount;
+        let amount_to_get = ratio_args.total_collateral_amount();
+        let filler_burn = ratio_args.filler_token_amount();
         let fee_amount = amount_to_get * fee_basis_points / build_arguments::MAX_BASIS_POINTS;
         let user_amount = amount_to_get - fee_amount;
 
@@ -1520,24 +1520,24 @@ mod dcd_merge_tests {
             DCDRatioArguments::build_from(1000, incentive_basis_points, strike_price, 10)?;
 
         let settlement_height = 100u32;
-        let dcd_arguments = DCDArguments {
-            taker_funding_start_time: now,
-            taker_funding_end_time: now,
-            contract_expiry_time: now,
-            early_termination_end_time: now,
+        let dcd_arguments = DCDArguments::new(
+            now,
+            now,
+            now,
+            now,
             settlement_height,
             strike_price,
             incentive_basis_points,
-            fee_basis_points: 0,
-            collateral_asset_id_hex_le: AssetId::LIQUID_BTC.to_string(),
-            settlement_asset_id_hex_le: LIQUID_TESTNET_TEST_ASSET_ID_STR.to_string(),
-            filler_token_asset_id_hex_le: first_asset_id.to_string(),
-            grantor_collateral_token_asset_id_hex_le: second_asset_id.to_string(),
-            grantor_settlement_token_asset_id_hex_le: third_asset_id.to_string(),
-            ratio_args: ratio_args.clone(),
-            oracle_public_key: oracle_kp.x_only_public_key().0.to_string(),
-            fee_script_hash_hex_le: "00".repeat(32),
-        };
+            0,
+            AssetId::LIQUID_BTC.to_string(),
+            LIQUID_TESTNET_TEST_ASSET_ID_STR.to_string(),
+            first_asset_id.to_string(),
+            second_asset_id.to_string(),
+            third_asset_id.to_string(),
+            ratio_args.clone(),
+            oracle_kp.x_only_public_key().0.to_string(),
+            "00".repeat(32),
+        );
 
         let keypair = Keypair::from_secret_key(
             &Secp256k1::new(),
@@ -1556,9 +1556,9 @@ mod dcd_merge_tests {
         pst.inputs_mut()[0].sequence = Some(elements::Sequence::ENABLE_LOCKTIME_NO_RBF);
 
         // Taker receives SETTLEMENT (price > strike): input is SETTLEMENT asset
-        let amount_to_get = ratio_args.total_asset_amount / 2; // 11000
-        let filler_burn = ratio_args.filler_token_amount / 2; // 100
-        let available_settlement = ratio_args.total_asset_amount;
+        let amount_to_get = ratio_args.total_asset_amount() / 2; // 11000
+        let filler_burn = ratio_args.filler_token_amount() / 2; // 100
+        let available_settlement = ratio_args.total_asset_amount();
 
         // 0: settlement change
         pst.add_output(Output::new_explicit(
@@ -1650,24 +1650,24 @@ mod dcd_merge_tests {
         let ratio_args =
             DCDRatioArguments::build_from(1000, incentive_basis_points, strike_price, 10)?;
 
-        let dcd_arguments = DCDArguments {
-            taker_funding_start_time: now,
-            taker_funding_end_time: now,
-            contract_expiry_time: now,
-            early_termination_end_time: now,
-            settlement_height: 0,
+        let dcd_arguments = DCDArguments::new(
+            now,
+            now,
+            now,
+            now,
+            0,
             strike_price,
             incentive_basis_points,
-            fee_basis_points: 0,
-            collateral_asset_id_hex_le: AssetId::LIQUID_BTC.to_string(),
-            settlement_asset_id_hex_le: LIQUID_TESTNET_TEST_ASSET_ID_STR.to_string(),
-            filler_token_asset_id_hex_le: first_asset_id.to_string(),
-            grantor_collateral_token_asset_id_hex_le: second_asset_id.to_string(),
-            grantor_settlement_token_asset_id_hex_le: third_asset_id.to_string(),
+            0,
+            AssetId::LIQUID_BTC.to_string(),
+            LIQUID_TESTNET_TEST_ASSET_ID_STR.to_string(),
+            first_asset_id.to_string(),
+            second_asset_id.to_string(),
+            third_asset_id.to_string(),
             ratio_args,
-            oracle_public_key: oracle_kp.x_only_public_key().0.to_string(),
-            fee_script_hash_hex_le: "00".repeat(32),
-        };
+            oracle_kp.x_only_public_key().0.to_string(),
+            "00".repeat(32),
+        );
 
         let keypair = Keypair::from_secret_key(
             &Secp256k1::new(),
@@ -1768,24 +1768,24 @@ mod dcd_merge_tests {
         let ratio_args =
             DCDRatioArguments::build_from(1000, incentive_basis_points, strike_price, 10)?;
 
-        let dcd_arguments = DCDArguments {
-            taker_funding_start_time: now,
-            taker_funding_end_time: now,
-            contract_expiry_time: now,
-            early_termination_end_time: now,
-            settlement_height: 0,
+        let dcd_arguments = DCDArguments::new(
+            now,
+            now,
+            now,
+            now,
+            0,
             strike_price,
             incentive_basis_points,
-            fee_basis_points: 0,
-            collateral_asset_id_hex_le: AssetId::LIQUID_BTC.to_string(),
-            settlement_asset_id_hex_le: LIQUID_TESTNET_TEST_ASSET_ID_STR.to_string(),
-            filler_token_asset_id_hex_le: first_asset_id.to_string(),
-            grantor_collateral_token_asset_id_hex_le: second_asset_id.to_string(),
-            grantor_settlement_token_asset_id_hex_le: third_asset_id.to_string(),
+            0,
+            AssetId::LIQUID_BTC.to_string(),
+            LIQUID_TESTNET_TEST_ASSET_ID_STR.to_string(),
+            first_asset_id.to_string(),
+            second_asset_id.to_string(),
+            third_asset_id.to_string(),
             ratio_args,
-            oracle_public_key: oracle_kp.x_only_public_key().0.to_string(),
-            fee_script_hash_hex_le: "00".repeat(32),
-        };
+            oracle_kp.x_only_public_key().0.to_string(),
+            "00".repeat(32),
+        );
 
         let keypair = Keypair::from_secret_key(
             &Secp256k1::new(),
@@ -1895,24 +1895,24 @@ mod dcd_merge_tests {
         let ratio_args =
             DCDRatioArguments::build_from(1000, incentive_basis_points, strike_price, 10)?;
 
-        let dcd_arguments = DCDArguments {
-            taker_funding_start_time: now,
-            taker_funding_end_time: now,
-            contract_expiry_time: now,
-            early_termination_end_time: now,
-            settlement_height: 0,
+        let dcd_arguments = DCDArguments::new(
+            now,
+            now,
+            now,
+            now,
+            0,
             strike_price,
             incentive_basis_points,
-            fee_basis_points: 0,
-            collateral_asset_id_hex_le: AssetId::LIQUID_BTC.to_string(),
-            settlement_asset_id_hex_le: LIQUID_TESTNET_TEST_ASSET_ID_STR.to_string(),
-            filler_token_asset_id_hex_le: first_asset_id.to_string(),
-            grantor_collateral_token_asset_id_hex_le: second_asset_id.to_string(),
-            grantor_settlement_token_asset_id_hex_le: third_asset_id.to_string(),
+            0,
+            AssetId::LIQUID_BTC.to_string(),
+            LIQUID_TESTNET_TEST_ASSET_ID_STR.to_string(),
+            first_asset_id.to_string(),
+            second_asset_id.to_string(),
+            third_asset_id.to_string(),
             ratio_args,
-            oracle_public_key: oracle_kp.x_only_public_key().0.to_string(),
-            fee_script_hash_hex_le: "00".repeat(32),
-        };
+            oracle_kp.x_only_public_key().0.to_string(),
+            "00".repeat(32),
+        );
 
         let keypair = Keypair::from_secret_key(
             &Secp256k1::new(),

--- a/crates/contracts/src/options/build_arguments.rs
+++ b/crates/contracts/src/options/build_arguments.rs
@@ -7,14 +7,14 @@ use simplicityhl::{Arguments, str::WitnessName, value::UIntValue};
 
 #[derive(Debug, Clone, bincode::Encode, bincode::Decode, PartialEq, Eq, Default)]
 pub struct OptionsArguments {
-    pub start_time: u32,
-    pub expiry_time: u32,
-    pub collateral_per_contract: u64,
-    pub settlement_per_contract: u64,
-    pub collateral_asset_id: [u8; 32],
-    pub settlement_asset_id: [u8; 32],
-    pub option_token_entropy: [u8; 32],
-    pub grantor_token_entropy: [u8; 32],
+    start_time: u32,
+    expiry_time: u32,
+    collateral_per_contract: u64,
+    settlement_per_contract: u64,
+    collateral_asset_id: [u8; 32],
+    settlement_asset_id: [u8; 32],
+    option_token_entropy: [u8; 32],
+    grantor_token_entropy: [u8; 32],
 }
 
 impl OptionsArguments {
@@ -49,6 +49,42 @@ impl OptionsArguments {
             )
             .0,
         }
+    }
+
+    /// Returns the start time.
+    #[must_use]
+    pub const fn start_time(&self) -> u32 {
+        self.start_time
+    }
+
+    /// Returns the expiry time.
+    #[must_use]
+    pub const fn expiry_time(&self) -> u32 {
+        self.expiry_time
+    }
+
+    /// Returns the collateral per contract amount.
+    #[must_use]
+    pub const fn collateral_per_contract(&self) -> u64 {
+        self.collateral_per_contract
+    }
+
+    /// Returns the settlement per contract amount.
+    #[must_use]
+    pub const fn settlement_per_contract(&self) -> u64 {
+        self.settlement_per_contract
+    }
+
+    /// Returns the option token entropy.
+    #[must_use]
+    pub const fn option_token_entropy(&self) -> [u8; 32] {
+        self.option_token_entropy
+    }
+
+    /// Returns the grantor token entropy.
+    #[must_use]
+    pub const fn grantor_token_entropy(&self) -> [u8; 32] {
+        self.grantor_token_entropy
     }
 
     #[must_use]
@@ -151,7 +187,8 @@ impl simplicityhl_core::Encodable for OptionsArguments {}
 mod tests {
     use super::*;
     use crate::sdk::taproot_pubkey_gen::get_random_seed;
-    use simplicityhl_core::Encodable;
+    use simplicityhl::elements::Txid;
+    use simplicityhl_core::{Encodable, LIQUID_TESTNET_BITCOIN_ASSET};
 
     #[test]
     fn test_serialize_deserialize_default() -> anyhow::Result<()> {
@@ -164,16 +201,17 @@ mod tests {
 
     #[test]
     fn test_serialize_deserialize_full() -> anyhow::Result<()> {
-        let args = OptionsArguments {
-            start_time: 10,
-            expiry_time: 50,
-            collateral_per_contract: 100,
-            settlement_per_contract: 1000,
-            collateral_asset_id: AssetId::LIQUID_BTC.into_inner().0,
-            settlement_asset_id: AssetId::LIQUID_BTC.into_inner().0,
-            option_token_entropy: get_random_seed(),
-            grantor_token_entropy: get_random_seed(),
-        };
+        let args = OptionsArguments::new(
+            10,
+            50,
+            100,
+            1000,
+            *LIQUID_TESTNET_BITCOIN_ASSET,
+            *LIQUID_TESTNET_BITCOIN_ASSET,
+            get_random_seed(),
+            OutPoint::new(Txid::from_slice(&[1; 32])?, 0),
+            OutPoint::new(Txid::from_slice(&[2; 32])?, 0),
+        );
 
         let serialized = args.encode()?;
         let deserialized = OptionsArguments::decode(&serialized)?;

--- a/crates/contracts/src/options/mod.rs
+++ b/crates/contracts/src/options/mod.rs
@@ -149,10 +149,10 @@ mod options_tests {
         build_option_cancellation, build_option_creation, build_option_exercise,
         build_option_expiry, build_option_funding, build_option_settlement,
     };
+    use simplicityhl::elements::Script;
     use simplicityhl::elements::pset::PartiallySignedTransaction;
     use simplicityhl::elements::secp256k1_zkp::SECP256K1;
     use simplicityhl::elements::taproot::ControlBlock;
-    use simplicityhl::elements::{ContractHash, Script};
     use simplicityhl::simplicity::jet::elements::ElementsUtxo;
     use simplicityhl_core::{LIQUID_TESTNET_BITCOIN_ASSET, LIQUID_TESTNET_TEST_ASSET_ID_STR};
 
@@ -171,26 +171,17 @@ mod options_tests {
 
         let issuance_asset_entropy = get_random_seed();
 
-        let option_arguments = OptionsArguments {
+        let option_arguments = OptionsArguments::new(
             start_time,
             expiry_time,
             collateral_per_contract,
             settlement_per_contract,
-            collateral_asset_id: LIQUID_TESTNET_BITCOIN_ASSET.into_inner().0,
-            settlement_asset_id: AssetId::from_str(LIQUID_TESTNET_TEST_ASSET_ID_STR)?
-                .into_inner()
-                .0,
-            option_token_entropy: AssetId::generate_asset_entropy(
-                option_outpoint,
-                ContractHash::from_byte_array(issuance_asset_entropy),
-            )
-            .0,
-            grantor_token_entropy: AssetId::generate_asset_entropy(
-                grantor_outpoint,
-                ContractHash::from_byte_array(issuance_asset_entropy),
-            )
-            .0,
-        };
+            *LIQUID_TESTNET_BITCOIN_ASSET,
+            AssetId::from_str(LIQUID_TESTNET_TEST_ASSET_ID_STR)?,
+            issuance_asset_entropy,
+            option_outpoint,
+            grantor_outpoint,
+        );
 
         Ok((
             build_option_creation(

--- a/crates/contracts/src/sdk/options/cancellation_option.rs
+++ b/crates/contracts/src/sdk/options/cancellation_option.rs
@@ -37,7 +37,7 @@ pub fn build_option_cancellation(
     );
     let (collateral_asset_id, total_collateral) = collateral_tx_out.explicit()?;
 
-    let collateral_amount_to_withdraw = amount_to_burn * option_arguments.collateral_per_contract;
+    let collateral_amount_to_withdraw = amount_to_burn * option_arguments.collateral_per_contract();
 
     if collateral_amount_to_withdraw > total_collateral {
         return Err(TransactionBuildError::InsufficientCollateral {

--- a/crates/contracts/src/sdk/options/exercise_option.rs
+++ b/crates/contracts/src/sdk/options/exercise_option.rs
@@ -41,8 +41,8 @@ pub fn build_option_exercise(
     let (option_token_id, total_option_token_amount) = option_tx_out.explicit()?;
     let (settlement_asset_id, total_asset_amount) = asset_tx_out.explicit()?;
 
-    let collateral_amount_to_get = amount_to_burn * option_arguments.collateral_per_contract;
-    let asset_amount_to_pay = amount_to_burn * option_arguments.settlement_per_contract;
+    let collateral_amount_to_get = amount_to_burn * option_arguments.collateral_per_contract();
+    let asset_amount_to_pay = amount_to_burn * option_arguments.settlement_per_contract();
 
     if collateral_amount_to_get > total_collateral {
         return Err(TransactionBuildError::InsufficientCollateral {
@@ -61,7 +61,8 @@ pub fn build_option_exercise(
     let contract_script = collateral_tx_out.script_pubkey.clone();
 
     let mut pst = PartiallySignedTransaction::new_v2();
-    pst.global.tx_data.fallback_locktime = Some(LockTime::from_time(option_arguments.start_time)?);
+    pst.global.tx_data.fallback_locktime =
+        Some(LockTime::from_time(option_arguments.start_time())?);
 
     let mut collateral_input = Input::from_prevout(collateral_out_point);
     collateral_input.witness_utxo = Some(collateral_tx_out.clone());

--- a/crates/contracts/src/sdk/options/expiry_option.rs
+++ b/crates/contracts/src/sdk/options/expiry_option.rs
@@ -46,7 +46,7 @@ pub fn build_option_expiry(
     }
 
     let collateral_amount =
-        grantor_token_amount_to_burn.saturating_mul(option_arguments.collateral_per_contract);
+        grantor_token_amount_to_burn.saturating_mul(option_arguments.collateral_per_contract());
 
     if collateral_amount > total_collateral {
         return Err(TransactionBuildError::InsufficientCollateral {
@@ -59,7 +59,8 @@ pub fn build_option_expiry(
     let contract_script = collateral_tx_out.script_pubkey.clone();
 
     let mut pst = PartiallySignedTransaction::new_v2();
-    pst.global.tx_data.fallback_locktime = Some(LockTime::from_time(option_arguments.start_time)?);
+    pst.global.tx_data.fallback_locktime =
+        Some(LockTime::from_time(option_arguments.start_time())?);
 
     let mut collateral_input = Input::from_prevout(collateral_out_point);
     collateral_input.witness_utxo = Some(collateral_tx_out.clone());

--- a/crates/contracts/src/sdk/options/funding_option.rs
+++ b/crates/contracts/src/sdk/options/funding_option.rs
@@ -41,7 +41,7 @@ pub fn build_option_funding(
     let (option_asset_id, option_token_id) = option_arguments.get_option_token_ids();
     let (grantor_asset_id, grantor_token_id) = option_arguments.get_grantor_token_ids();
 
-    let option_token_amount = collateral_amount / option_arguments.collateral_per_contract;
+    let option_token_amount = collateral_amount / option_arguments.collateral_per_contract();
 
     let change_recipient_script = collateral_tx_out.script_pubkey.clone();
     let contract_script = option_tx_out.script_pubkey.clone();
@@ -52,7 +52,7 @@ pub fn build_option_funding(
     first_reissuance_tx.witness_utxo = Some(option_tx_out.clone());
     first_reissuance_tx.issuance_value_amount = Some(option_token_amount);
     first_reissuance_tx.issuance_inflation_keys = None;
-    first_reissuance_tx.issuance_asset_entropy = Some(option_arguments.option_token_entropy);
+    first_reissuance_tx.issuance_asset_entropy = Some(option_arguments.option_token_entropy());
     first_reissuance_tx.blinded_issuance = Some(0x00);
     first_reissuance_tx.issuance_blinding_nonce =
         Some(option_tx_out_unblinded.asset_bf.into_inner());
@@ -62,7 +62,7 @@ pub fn build_option_funding(
     second_reissuance_tx.witness_utxo = Some(grantor_tx_out.clone());
     second_reissuance_tx.issuance_value_amount = Some(option_token_amount);
     second_reissuance_tx.issuance_inflation_keys = None;
-    second_reissuance_tx.issuance_asset_entropy = Some(option_arguments.grantor_token_entropy);
+    second_reissuance_tx.issuance_asset_entropy = Some(option_arguments.grantor_token_entropy());
     second_reissuance_tx.blinded_issuance = Some(0x00);
     second_reissuance_tx.issuance_blinding_nonce =
         Some(grantor_tx_out_unblinded.asset_bf.into_inner());
@@ -191,7 +191,7 @@ pub fn build_option_funding(
     pst.extract_tx()?
         .verify_tx_amt_proofs(secp256k1::SECP256K1, &utxos)?;
 
-    let expected_asset_amount = option_token_amount * option_arguments.settlement_per_contract;
+    let expected_asset_amount = option_token_amount * option_arguments.settlement_per_contract();
     let option_branch = OptionBranch::Funding {
         expected_asset_amount,
     };

--- a/crates/contracts/src/sdk/options/settlement_option.rs
+++ b/crates/contracts/src/sdk/options/settlement_option.rs
@@ -54,7 +54,7 @@ pub fn build_option_settlement(
     }
 
     let asset_amount =
-        grantor_token_amount_to_burn.saturating_mul(option_arguments.settlement_per_contract);
+        grantor_token_amount_to_burn.saturating_mul(option_arguments.settlement_per_contract());
 
     if asset_amount > available_settlement_asset {
         return Err(TransactionBuildError::InsufficientSettlementAsset {
@@ -67,7 +67,8 @@ pub fn build_option_settlement(
     let contract_script = settlement_tx_out.script_pubkey.clone();
 
     let mut pst = PartiallySignedTransaction::new_v2();
-    pst.global.tx_data.fallback_locktime = Some(LockTime::from_time(option_arguments.start_time)?);
+    pst.global.tx_data.fallback_locktime =
+        Some(LockTime::from_time(option_arguments.start_time())?);
 
     let mut settlement_input = Input::from_prevout(settlement_out_point);
     settlement_input.witness_utxo = Some(settlement_tx_out.clone());

--- a/crates/contracts/src/sdk/swap_with_change/exercise.rs
+++ b/crates/contracts/src/sdk/swap_with_change/exercise.rs
@@ -70,7 +70,7 @@ pub fn build_swap_exercise(
     }
 
     let settlement_amount_required = collateral_amount_to_receive
-        .checked_mul(arguments.collateral_per_contract)
+        .checked_mul(arguments.collateral_per_contract())
         .ok_or(TransactionBuildError::InsufficientSettlementAsset {
             required: u64::MAX,
             available: total_settlement,

--- a/crates/contracts/src/sdk/swap_with_change/expiry.rs
+++ b/crates/contracts/src/sdk/swap_with_change/expiry.rs
@@ -52,7 +52,7 @@ pub fn build_swap_expiry(
 
     let mut pst = PartiallySignedTransaction::new_v2();
 
-    pst.global.tx_data.fallback_locktime = Some(LockTime::from_time(arguments.expiry_time)?);
+    pst.global.tx_data.fallback_locktime = Some(LockTime::from_time(arguments.expiry_time())?);
 
     let mut collateral_input = Input::from_prevout(collateral_outpoint);
     collateral_input.witness_utxo = Some(collateral_tx_out.clone());

--- a/crates/contracts/src/simple_storage/build_arguments.rs
+++ b/crates/contracts/src/simple_storage/build_arguments.rs
@@ -7,8 +7,31 @@ use simplicityhl::{Arguments, str::WitnessName, value::UIntValue};
 
 #[derive(Debug, Clone, bincode::Encode, bincode::Decode, PartialEq, Eq)]
 pub struct StorageArguments {
-    pub public_key: [u8; 32],
-    pub slot_asset: String,
+    public_key: [u8; 32],
+    slot_asset: String,
+}
+
+impl StorageArguments {
+    /// Create new storage arguments.
+    #[must_use]
+    pub const fn new(public_key: [u8; 32], slot_asset: String) -> Self {
+        Self {
+            public_key,
+            slot_asset,
+        }
+    }
+
+    /// Returns the public key.
+    #[must_use]
+    pub const fn public_key(&self) -> [u8; 32] {
+        self.public_key
+    }
+
+    /// Returns the slot asset.
+    #[must_use]
+    pub const fn slot_asset(&self) -> &String {
+        &self.slot_asset
+    }
 }
 
 /// Build Simplicity arguments for storage program.
@@ -17,7 +40,7 @@ pub struct StorageArguments {
 /// Panics if the slot asset hex string is invalid.
 #[must_use]
 pub fn build_storage_arguments(args: &StorageArguments) -> Arguments {
-    let mut slot_id = <[u8; 32]>::from_hex(&args.slot_asset).unwrap();
+    let mut slot_id = <[u8; 32]>::from_hex(args.slot_asset()).unwrap();
     slot_id.reverse();
 
     Arguments::from(HashMap::from([

--- a/crates/contracts/src/simple_storage/mod.rs
+++ b/crates/contracts/src/simple_storage/mod.rs
@@ -109,10 +109,10 @@ mod simple_storage_tests {
             &secp256k1::SecretKey::from_slice(&[1u8; 32])?,
         );
 
-        let storage_arguments = StorageArguments {
-            public_key: keypair.x_only_public_key().0.serialize(),
-            slot_asset: LIQUID_TESTNET_BITCOIN_ASSET.to_string(),
-        };
+        let storage_arguments = StorageArguments::new(
+            keypair.x_only_public_key().0.serialize(),
+            LIQUID_TESTNET_BITCOIN_ASSET.to_string(),
+        );
 
         let storage_address = get_storage_address(
             &keypair.x_only_public_key().0,
@@ -183,10 +183,10 @@ mod simple_storage_tests {
             &secp256k1::SecretKey::from_slice(&[1u8; 32])?,
         );
 
-        let storage_arguments = StorageArguments {
-            public_key: keypair.x_only_public_key().0.serialize(),
-            slot_asset: LIQUID_TESTNET_BITCOIN_ASSET.to_string(),
-        };
+        let storage_arguments = StorageArguments::new(
+            keypair.x_only_public_key().0.serialize(),
+            LIQUID_TESTNET_BITCOIN_ASSET.to_string(),
+        );
 
         let storage_address = get_storage_address(
             &keypair.x_only_public_key().0,

--- a/crates/contracts/src/swap_with_change/mod.rs
+++ b/crates/contracts/src/swap_with_change/mod.rs
@@ -154,8 +154,8 @@ mod swap_with_change_tests {
     use simplicityhl::simplicity::elements::{self, OutPoint, Txid};
     use simplicityhl::simplicity::hashes::Hash;
 
-    use simplicityhl::elements::Script;
     use simplicityhl::elements::taproot::ControlBlock;
+    use simplicityhl::elements::{AssetId, Script};
     use simplicityhl::simplicity::jet::elements::ElementsUtxo;
     use simplicityhl_core::{
         LIQUID_TESTNET_BITCOIN_ASSET, LIQUID_TESTNET_GENESIS, get_and_verify_env, get_p2pk_address,
@@ -169,13 +169,13 @@ mod swap_with_change_tests {
         x_only_public_key: &XOnlyPublicKey,
         expiry_time: u32,
     ) -> SwapWithChangeArguments {
-        SwapWithChangeArguments {
-            collateral_asset_id: [1u8; 32],
-            settlement_asset_id: LIQUID_TESTNET_BITCOIN_ASSET.into_inner().0,
-            collateral_per_contract: 100,
+        SwapWithChangeArguments::new(
+            AssetId::from_slice(&[1u8; 32]).unwrap(),
+            *LIQUID_TESTNET_BITCOIN_ASSET,
+            100,
             expiry_time,
-            user_pubkey: x_only_public_key.serialize(),
-        }
+            x_only_public_key.serialize(),
+        )
     }
 
     #[test]
@@ -252,7 +252,7 @@ mod swap_with_change_tests {
 
         let input_collateral_amount = 1000u64;
         let collateral_to_receive = 400u64;
-        let settlement_required = collateral_to_receive * args.collateral_per_contract;
+        let settlement_required = collateral_to_receive * args.collateral_per_contract();
         let fee_amount = 500u64;
 
         let (pst, branch) = build_swap_exercise(
@@ -341,7 +341,7 @@ mod swap_with_change_tests {
 
         let input_collateral_amount = 1000u64;
         let collateral_to_receive = 1000u64;
-        let settlement_required = collateral_to_receive * args.collateral_per_contract;
+        let settlement_required = collateral_to_receive * args.collateral_per_contract();
         let fee_amount = 500u64;
 
         let (pst, branch) = build_swap_exercise(


### PR DESCRIPTION
Before, all fields in argument structures were public, which led to bad DX

As the first part of the refactoring, I made all of them private and added the necessary getters and constructors