### PR TITLE
Add an ability to reconstruct Args structure

### DIFF
--- a/crates/cli/src/commands/options.rs
+++ b/crates/cli/src/commands/options.rs
@@ -270,8 +270,8 @@ impl Options {
                     *LIQUID_TESTNET_BITCOIN_ASSET,
                     settlement_asset_id,
                     issuance_asset_entropy,
-                    *first_fee_utxo,
-                    *second_fee_utxo,
+                    (*first_fee_utxo, false),
+                    (*second_fee_utxo, false),
                 );
 
                 let (pst, options_taproot_pubkey_gen) = contracts::sdk::build_option_creation(

--- a/crates/cli/src/modules/store.rs
+++ b/crates/cli/src/modules/store.rs
@@ -114,8 +114,8 @@ mod tests {
             *LIQUID_TESTNET_BITCOIN_ASSET,
             settlement_asset_id,
             get_random_seed(),
-            OutPoint::new(Txid::from_slice(&[1; 32])?, 0),
-            OutPoint::new(Txid::from_slice(&[2; 32])?, 0),
+            (OutPoint::new(Txid::from_slice(&[1; 32])?, 0), false),
+            (OutPoint::new(Txid::from_slice(&[2; 32])?, 0), false),
         );
 
         let options_taproot_pubkey_gen =

--- a/crates/contracts/src/arguments_helpers.rs
+++ b/crates/contracts/src/arguments_helpers.rs
@@ -1,0 +1,93 @@
+use simplicityhl::Arguments;
+use simplicityhl::str::WitnessName;
+use simplicityhl::value::{UIntValue, ValueInner};
+
+use crate::error::FromArgumentsError;
+
+/// Extract a U256 value as `[u8; 32]` from Arguments by witness name.
+///
+/// # Errors
+///
+/// Returns error if the witness is missing or has wrong type.
+pub fn extract_u256_bytes(args: &Arguments, name: &str) -> Result<[u8; 32], FromArgumentsError> {
+    let witness_name = WitnessName::from_str_unchecked(name);
+    let value = args
+        .get(&witness_name)
+        .ok_or_else(|| FromArgumentsError::MissingWitness {
+            name: name.to_string(),
+        })?;
+
+    match value.inner() {
+        ValueInner::UInt(UIntValue::U256(u256)) => Ok(u256.to_byte_array()),
+        _ => Err(FromArgumentsError::WrongValueType {
+            name: name.to_string(),
+            expected: "U256".to_string(),
+        }),
+    }
+}
+
+/// Extract a U64 value from Arguments by witness name.
+///
+/// # Errors
+///
+/// Returns error if the witness is missing or has wrong type.
+pub fn extract_u64(args: &Arguments, name: &str) -> Result<u64, FromArgumentsError> {
+    let witness_name = WitnessName::from_str_unchecked(name);
+    let value = args
+        .get(&witness_name)
+        .ok_or_else(|| FromArgumentsError::MissingWitness {
+            name: name.to_string(),
+        })?;
+
+    match value.inner() {
+        ValueInner::UInt(UIntValue::U64(v)) => Ok(*v),
+        _ => Err(FromArgumentsError::WrongValueType {
+            name: name.to_string(),
+            expected: "U64".to_string(),
+        }),
+    }
+}
+
+/// Extract a U32 value from Arguments by witness name.
+///
+/// # Errors
+///
+/// Returns error if the witness is missing or has wrong type.
+pub fn extract_u32(args: &Arguments, name: &str) -> Result<u32, FromArgumentsError> {
+    let witness_name = WitnessName::from_str_unchecked(name);
+    let value = args
+        .get(&witness_name)
+        .ok_or_else(|| FromArgumentsError::MissingWitness {
+            name: name.to_string(),
+        })?;
+
+    match value.inner() {
+        ValueInner::UInt(UIntValue::U32(v)) => Ok(*v),
+        _ => Err(FromArgumentsError::WrongValueType {
+            name: name.to_string(),
+            expected: "U32".to_string(),
+        }),
+    }
+}
+
+/// Extract a boolean value from Arguments by witness name.
+///
+/// # Errors
+///
+/// Returns error if the witness is missing or has wrong type.
+pub fn extract_bool(args: &Arguments, name: &str) -> Result<bool, FromArgumentsError> {
+    let witness_name = WitnessName::from_str_unchecked(name);
+    let value = args
+        .get(&witness_name)
+        .ok_or_else(|| FromArgumentsError::MissingWitness {
+            name: name.to_string(),
+        })?;
+
+    match value.inner() {
+        ValueInner::Boolean(b) => Ok(*b),
+        _ => Err(FromArgumentsError::WrongValueType {
+            name: name.to_string(),
+            expected: "bool".to_string(),
+        }),
+    }
+}

--- a/crates/contracts/src/error.rs
+++ b/crates/contracts/src/error.rs
@@ -122,6 +122,19 @@ pub enum TransactionBuildError {
     TaprootPubkeyGen(#[from] TaprootPubkeyGenError),
 }
 
+/// Errors from extracting arguments from Arguments struct.
+#[derive(Debug, thiserror::Error)]
+pub enum FromArgumentsError {
+    #[error("Missing witness name: {name}")]
+    MissingWitness { name: String },
+
+    #[error("Wrong value type for {name}: expected {expected}")]
+    WrongValueType { name: String, expected: String },
+
+    #[error("Invalid asset ID bytes for {name}")]
+    InvalidAssetId { name: String },
+}
+
 /// Errors from DCD ratio calculations.
 #[cfg(feature = "dcd")]
 #[derive(Debug, thiserror::Error)]

--- a/crates/contracts/src/lib.rs
+++ b/crates/contracts/src/lib.rs
@@ -1,6 +1,7 @@
 #![warn(clippy::all, clippy::pedantic)]
 extern crate core;
 
+pub mod arguments_helpers;
 pub mod error;
 
 pub mod sdk;

--- a/crates/contracts/src/options/mod.rs
+++ b/crates/contracts/src/options/mod.rs
@@ -179,8 +179,8 @@ mod options_tests {
             *LIQUID_TESTNET_BITCOIN_ASSET,
             AssetId::from_str(LIQUID_TESTNET_TEST_ASSET_ID_STR)?,
             issuance_asset_entropy,
-            option_outpoint,
-            grantor_outpoint,
+            (option_outpoint, false),
+            (grantor_outpoint, false),
         );
 
         Ok((


### PR DESCRIPTION
The core motivation for extending the arguments is to improve DX

Currently, this outweighs the need to keep arguments as minimal as possible (all data that is in Arguments is public)