### PR TITLE
Usage of `PartialPset` in code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -349,6 +349,7 @@ dependencies = [
  "anyhow",
  "bincode",
  "hex",
+ "minreq",
  "ring",
  "sha2",
  "simplicityhl",
@@ -683,6 +684,8 @@ checksum = "05015102dad0f7d61691ca347e9d9d9006685a64aefb3d79eecf62665de2153d"
 dependencies = [
  "rustls",
  "rustls-webpki",
+ "serde",
+ "serde_json",
  "webpki-roots",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,8 @@ sha2 = { version = "0.10.9", features = ["compress"] }
 hex = "0.4.3"
 tracing = { version = "0.1.41" }
 
+minreq = { version = "2.14.1", features = ["https", "json-using-serde"]}
+
 simplicityhl = { version = "0.4.0" }
 simplicityhl-core = { version = "0.4.1", features = ["encoding"] }
 

--- a/crates/contracts/Cargo.toml
+++ b/crates/contracts/Cargo.toml
@@ -32,6 +32,8 @@ sha2 = { workspace = true }
 
 hex = { workspace = true }
 
+minreq = { workspace = true }
+
 simplicityhl = { workspace = true }
 
 simplicityhl-core = { workspace = true }

--- a/crates/contracts/src/error.rs
+++ b/crates/contracts/src/error.rs
@@ -1,3 +1,5 @@
+use simplicityhl::elements::AssetId;
+
 /// Errors from UTXO validation operations.
 #[derive(Debug, thiserror::Error)]
 pub enum ValidationError {
@@ -123,6 +125,44 @@ pub enum TransactionBuildError {
 
     #[error(transparent)]
     TaprootPubkeyGen(#[from] TaprootPubkeyGenError),
+
+    #[error("Wrong asset for paying fees, got: {got}, expected: {expected}")]
+    IncorrectFeeAsset { got: AssetId, expected: AssetId },
+
+    #[error(
+        "Insufficient funds: available: {available} units for asset '{asset_id}', has to be at least: {has_to_be}"
+    )]
+    InsufficientAssetAmount {
+        available: u64,
+        has_to_be: u64,
+        asset_id: AssetId,
+    },
+
+    #[error("Transaction dymmy signer signature error: {0}")]
+    PsetDummySign(simplicityhl_core::ProgramError),
+
+    #[error("Transaction signature error: {0}")]
+    PsetSign(simplicityhl_core::ProgramError),
+
+    #[error("Fee rate for building transaction missing")]
+    FeeRateIsEmpty,
+
+    #[error("Tx out is absent with index: {id} and description: {description:?}")]
+    NoTxOut {
+        description: Option<String>,
+        id: usize,
+    },
+
+    #[error(
+        "Tx out secret for blinding is absent with index: {id} and description: {description:?}"
+    )]
+    NoTxOutSecret {
+        description: Option<String>,
+        id: usize,
+    },
+
+    #[error("Missing tx out secrets for blinding")]
+    MissingTxOutSecrets,
 }
 
 /// Errors from extracting arguments from Arguments struct.

--- a/crates/contracts/src/finance/option_offer/mod.rs
+++ b/crates/contracts/src/finance/option_offer/mod.rs
@@ -157,8 +157,8 @@ mod option_offer_tests {
     };
 
     use crate::sdk::{
-        build_option_offer_deposit, build_option_offer_exercise, build_option_offer_expiry,
-        build_option_offer_withdraw,
+        DummySigner, build_option_offer_deposit, build_option_offer_exercise,
+        build_option_offer_expiry, build_option_offer_withdraw,
     };
 
     const NETWORK: SimplicityNetwork = SimplicityNetwork::LiquidTestnet;
@@ -191,7 +191,7 @@ mod option_offer_tests {
         let premium_deposit_amount = collateral_deposit_amount * args.premium_per_collateral();
         let fee_amount = 500u64;
 
-        let (pst, _) = build_option_offer_deposit(
+        let (partial_pset, _) = build_option_offer_deposit(
             (
                 OutPoint::new(Txid::from_slice(&[1; 32])?, 0),
                 TxOut {
@@ -223,12 +223,12 @@ mod option_offer_tests {
                 },
             ),
             collateral_deposit_amount,
-            fee_amount,
             &args,
             NETWORK,
         )?;
 
-        let tx = pst.extract_tx()?;
+        let partial_pset = partial_pset.fee(99);
+        let tx = partial_pset.finalize(NETWORK, DummySigner::get_signer_closure())?;
 
         assert_eq!(
             tx.output[0].asset,
@@ -270,7 +270,7 @@ mod option_offer_tests {
         let settlement_required = collateral_to_receive * args.collateral_per_contract();
         let fee_amount = 500u64;
 
-        let (pst, branch) = build_option_offer_exercise(
+        let (partial_pset, branch) = build_option_offer_exercise(
             (
                 OutPoint::new(Txid::from_slice(&[1; 32])?, 0),
                 TxOut {
@@ -312,12 +312,12 @@ mod option_offer_tests {
                 },
             ),
             collateral_to_receive,
-            fee_amount,
             &args,
             change_recipient.script_pubkey(),
         )?;
 
-        let tx = pst.extract_tx()?;
+        let partial_pset = partial_pset.fee(99);
+        let tx = partial_pset.finalize(NETWORK, DummySigner::get_signer_closure())?;
 
         let env = ElementsEnv::new(
             Arc::new(tx),
@@ -371,7 +371,7 @@ mod option_offer_tests {
         let settlement_required = collateral_to_receive * args.collateral_per_contract();
         let fee_amount = 500u64;
 
-        let (pst, branch) = build_option_offer_exercise(
+        let (partial_pset, branch) = build_option_offer_exercise(
             (
                 OutPoint::new(Txid::from_slice(&[1; 32])?, 0),
                 TxOut {
@@ -413,12 +413,12 @@ mod option_offer_tests {
                 },
             ),
             collateral_to_receive,
-            fee_amount,
             &args,
             change_recipient.script_pubkey(),
         )?;
 
-        let tx = pst.extract_tx()?;
+        let partial_pset = partial_pset.fee(99);
+        let tx = partial_pset.finalize(NETWORK, DummySigner::get_signer_closure())?;
 
         let env = ElementsEnv::new(
             Arc::new(tx),
@@ -469,7 +469,7 @@ mod option_offer_tests {
         let settlement_amount = 50000u64;
         let fee_amount = 500u64;
 
-        let pst = build_option_offer_withdraw(
+        let partial_pset = build_option_offer_withdraw(
             (
                 OutPoint::new(Txid::from_slice(&[1; 32])?, 0),
                 TxOut {
@@ -490,12 +490,12 @@ mod option_offer_tests {
                     witness: elements::TxOutWitness::default(),
                 },
             ),
-            fee_amount,
             &args,
             change_recipient.script_pubkey(),
         )?;
 
-        let tx = pst.extract_tx()?;
+        let partial_pset = partial_pset.fee(99);
+        let tx = partial_pset.finalize(NETWORK, DummySigner::get_signer_closure())?;
 
         let utxos = vec![
             TxOut {
@@ -560,7 +560,7 @@ mod option_offer_tests {
         let premium_amount = collateral_amount * args.premium_per_collateral();
         let fee_amount = 500u64;
 
-        let pst = build_option_offer_expiry(
+        let partial_pset = build_option_offer_expiry(
             (
                 OutPoint::new(Txid::from_slice(&[1; 32])?, 0),
                 TxOut {
@@ -591,12 +591,12 @@ mod option_offer_tests {
                     witness: elements::TxOutWitness::default(),
                 },
             ),
-            fee_amount,
             &args,
             change_recipient.script_pubkey(),
         )?;
 
-        let tx = pst.extract_tx()?;
+        let partial_pset = partial_pset.fee(99);
+        let tx = partial_pset.finalize(NETWORK, DummySigner::get_signer_closure())?;
 
         let utxos = vec![
             TxOut {

--- a/crates/contracts/src/sdk/basic/reissue_asset.rs
+++ b/crates/contracts/src/sdk/basic/reissue_asset.rs
@@ -1,13 +1,10 @@
 use crate::error::TransactionBuildError;
-use crate::sdk::validation::TxOutExt;
-
 use std::collections::HashMap;
 
-use simplicityhl::elements::bitcoin::secp256k1;
+use crate::sdk::PartialPset;
 use simplicityhl::elements::hashes::sha256::Midstate;
 use simplicityhl::elements::pset::{Input, Output, PartiallySignedTransaction};
 use simplicityhl::elements::secp256k1_zkp::PublicKey;
-use simplicityhl::elements::secp256k1_zkp::rand::thread_rng;
 use simplicityhl::elements::{AssetId, OutPoint, TxOut, TxOutSecrets};
 
 /// Reissue an existing asset by spending its reissuance token.
@@ -25,16 +22,10 @@ pub fn reissue_asset(
     reissue_utxo_secrets: TxOutSecrets,
     fee_utxo: (OutPoint, TxOut),
     reissue_amount: u64,
-    fee_amount: u64,
     asset_entropy: Midstate,
-) -> Result<PartiallySignedTransaction, TransactionBuildError> {
+) -> Result<PartialPset, TransactionBuildError> {
     let (reissue_out_point, reissue_tx_out) = reissue_utxo;
     let (fee_out_point, fee_tx_out) = fee_utxo;
-
-    let (fee_asset_id, total_lbtc_left) = (
-        fee_tx_out.explicit_asset()?,
-        fee_tx_out.validate_amount(fee_amount)?,
-    );
 
     let change_recipient_script = fee_tx_out.script_pubkey.clone();
 
@@ -88,19 +79,10 @@ pub fn reissue_asset(
         None,
     ));
 
-    pst.add_output(Output::new_explicit(
+    Ok(PartialPset::new(
+        pst,
         change_recipient_script,
-        total_lbtc_left,
-        fee_asset_id,
-        None,
-    ));
-
-    pst.add_output(Output::from_txout(TxOut::new_fee(fee_amount, fee_asset_id)));
-
-    pst.blind_last(&mut thread_rng(), secp256k1::SECP256K1, &inp_txout_sec)?;
-
-    pst.extract_tx()?
-        .verify_tx_amt_proofs(secp256k1::SECP256K1, &[reissue_tx_out, fee_tx_out])?;
-
-    Ok(pst)
+        vec![reissue_tx_out, fee_tx_out],
+    )
+    .inp_tx_out_secrets(inp_txout_sec))
 }

--- a/crates/contracts/src/sdk/basic/split_native_any.rs
+++ b/crates/contracts/src/sdk/basic/split_native_any.rs
@@ -1,7 +1,7 @@
 use crate::error::TransactionBuildError;
-use crate::sdk::validation::TxOutExt;
 
-use simplicityhl::elements::bitcoin::secp256k1;
+use crate::sdk::PartialPset;
+use crate::sdk::validation::TxOutExt;
 use simplicityhl::elements::pset::{Input, Output, PartiallySignedTransaction};
 use simplicityhl::elements::{OutPoint, TxOut};
 
@@ -15,18 +15,14 @@ use simplicityhl::elements::{OutPoint, TxOut};
 pub fn split_native_any(
     utxo: (OutPoint, TxOut),
     parts_to_split: u64,
-    fee_amount: u64,
-) -> Result<PartiallySignedTransaction, TransactionBuildError> {
+) -> Result<PartialPset, TransactionBuildError> {
     if parts_to_split == 0 {
         return Err(TransactionBuildError::InvalidSplitParts);
     }
 
     let (out_point, tx_out) = utxo;
 
-    let (asset_id, total_lbtc_left) = (
-        tx_out.explicit_asset()?,
-        tx_out.validate_amount(fee_amount)?,
-    );
+    let (policy_asset_id, total_policy_asset_left) = tx_out.explicit()?;
 
     let recipient_script = tx_out.script_pubkey.clone();
 
@@ -36,29 +32,16 @@ pub fn split_native_any(
     input.witness_utxo = Some(tx_out.clone());
     pst.add_input(input);
 
-    let split_amount = total_lbtc_left / parts_to_split;
-    let change_amount = total_lbtc_left - split_amount * (parts_to_split - 1);
+    let split_amount = total_policy_asset_left / parts_to_split;
 
     for _ in 0..(parts_to_split - 1) {
         pst.add_output(Output::new_explicit(
             recipient_script.clone(),
             split_amount,
-            asset_id,
+            policy_asset_id,
             None,
         ));
     }
 
-    pst.add_output(Output::new_explicit(
-        recipient_script,
-        change_amount,
-        asset_id,
-        None,
-    ));
-
-    pst.add_output(Output::from_txout(TxOut::new_fee(fee_amount, asset_id)));
-
-    pst.extract_tx()?
-        .verify_tx_amt_proofs(secp256k1::SECP256K1, &[tx_out])?;
-
-    Ok(pst)
+    Ok(PartialPset::new(pst, recipient_script, vec![tx_out]))
 }

--- a/crates/contracts/src/sdk/basic/transfer_native.rs
+++ b/crates/contracts/src/sdk/basic/transfer_native.rs
@@ -1,7 +1,8 @@
 use crate::error::TransactionBuildError;
+
+use crate::sdk::PartialPset;
 use crate::sdk::validation::TxOutExt;
 
-use simplicityhl::elements::bitcoin::secp256k1;
 use simplicityhl::elements::pset::{Input, Output, PartiallySignedTransaction};
 use simplicityhl::elements::{Address, OutPoint, TxOut};
 
@@ -16,14 +17,10 @@ pub fn transfer_native(
     utxo: (OutPoint, TxOut),
     to_address: &Address,
     amount_to_send: u64,
-    fee_amount: u64,
-) -> Result<PartiallySignedTransaction, TransactionBuildError> {
+) -> Result<PartialPset, TransactionBuildError> {
     let (out_point, tx_out) = utxo;
 
-    let (asset_id, total_lbtc_left) = (
-        tx_out.explicit_asset()?,
-        tx_out.validate_amount(amount_to_send + fee_amount)?,
-    );
+    let asset_id = tx_out.explicit_asset()?;
 
     let change_recipient_script = tx_out.script_pubkey.clone();
 
@@ -40,17 +37,5 @@ pub fn transfer_native(
         None,
     ));
 
-    pst.add_output(Output::new_explicit(
-        change_recipient_script,
-        total_lbtc_left,
-        asset_id,
-        None,
-    ));
-
-    pst.add_output(Output::from_txout(TxOut::new_fee(fee_amount, asset_id)));
-
-    pst.extract_tx()?
-        .verify_tx_amt_proofs(secp256k1::SECP256K1, &[tx_out])?;
-
-    Ok(pst)
+    Ok(PartialPset::new(pst, change_recipient_script, vec![tx_out]))
 }

--- a/crates/contracts/src/sdk/fee_rate_fetcher.rs
+++ b/crates/contracts/src/sdk/fee_rate_fetcher.rs
@@ -1,0 +1,126 @@
+use std::collections::HashMap;
+
+/// Fee estimates response from Esplora.
+/// Key: confirmation target (in blocks as string), Value: fee rate (sat/vB).
+pub type FeeEstimates = HashMap<String, f64>;
+
+/// Default Target blocks value for using `DEFAULT_FEE_RATE` later
+pub const DEFAULT_TARGET_BLOCKS: u32 = 0;
+
+/// Default fallback fee rate in sats/kvb (0.10 sat/vB).
+/// Higher than LWK default to meet Liquid minimum relay fee requirements.
+pub const DEFAULT_FEE_RATE: f32 = 100.0;
+
+/// Error type for Esplora sync operations.
+#[derive(thiserror::Error, Debug)]
+pub enum FeeFetcherError {
+    #[error("HTTP request failed: {0}")]
+    Request(String),
+
+    #[error("Failed to deserialize response: {0}")]
+    Deserialize(String),
+
+    #[error("Invalid txid format: {0}")]
+    InvalidTxid(String),
+}
+
+pub trait SyncFeeFetcher {
+    /// Fetch fee estimates for various confirmation targets.
+    ///
+    /// # Errors
+    ///
+    /// Returns error if the HTTP request fails or response body cannot be parsed.
+    fn fetch_fee_estimates() -> Result<FeeEstimates, FeeFetcherError>;
+
+    /// Get fee rate for a specific confirmation target.
+    ///
+    /// Fetches fee estimates from Esplora and returns the rate for the given target.
+    /// If the exact target is not available, falls back to higher targets.
+    ///
+    /// # Arguments
+    ///
+    /// * `target_blocks` - Desired confirmation target in blocks (1-25, 144, 504, 1008)
+    ///
+    /// # Returns
+    ///
+    /// Fee rate in sats/kvb (satoshis per 1000 virtual bytes).
+    /// Multiply Esplora's sat/vB value by 1000.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the `fetch_fee_estimates()` fails or no suitable fee rate is found.
+    #[allow(clippy::cast_possible_truncation)]
+    fn get_fee_rate(target_blocks: u32) -> Result<f32, FeeFetcherError> {
+        if target_blocks == 0 {
+            return Ok(DEFAULT_FEE_RATE);
+        }
+
+        let estimates = Self::fetch_fee_estimates()?;
+
+        let target_str = target_blocks.to_string();
+        if let Some(&rate) = estimates.get(&target_str) {
+            return Ok((rate * 1000.0) as f32); // Convert sat/vB to sats/kvb
+        }
+
+        // Fall back to higher targets (lower fee rates)
+        // Available targets: 1-25, 144, 504, 1008
+        let fallback_targets = [
+            1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
+            25, 144, 504, 1008,
+        ];
+
+        for &target in fallback_targets.iter().filter(|&&t| t >= target_blocks) {
+            let key = target.to_string();
+            if let Some(&rate) = estimates.get(&key) {
+                return Ok((rate * 1000.0) as f32);
+            }
+        }
+
+        // If no higher target found, try any available rate (use lowest target = highest rate)
+        for &target in &fallback_targets {
+            let key = target.to_string();
+            if let Some(&rate) = estimates.get(&key) {
+                return Ok((rate * 1000.0) as f32);
+            }
+        }
+
+        Err(FeeFetcherError::Request(
+            "No fee estimates available".to_string(),
+        ))
+    }
+}
+
+pub struct EsploraFeeFetcher;
+
+impl SyncFeeFetcher for EsploraFeeFetcher {
+    /// Fetch fee estimates for various confirmation targets.
+    ///
+    /// Uses the `GET /fee-estimates` endpoint.
+    /// Note: Liquid testnet typically returns empty results, so callers should
+    /// use a fallback rate (see `config.fee.fallback_rate`).
+    ///
+    /// Returns a map where key is confirmation target (blocks) and value is fee rate (sat/vB).
+    ///
+    /// Example response: `{ "1": 87.882, "2": 87.882, ..., "144": 1.027, "1008": 1.027 }`
+    fn fetch_fee_estimates() -> Result<FeeEstimates, FeeFetcherError> {
+        const ESPLORA_URL: &str = "https://blockstream.info/liquidtestnet/api";
+
+        let url = format!("{ESPLORA_URL}/fee-estimates");
+        let response = minreq::get(&url)
+            .send()
+            .map_err(|e| FeeFetcherError::Request(e.to_string()))?;
+
+        if response.status_code != 200 {
+            return Err(FeeFetcherError::Request(format!(
+                "HTTP {}: {}",
+                response.status_code, response.reason_phrase
+            )));
+        }
+
+        let estimates: FeeEstimates = response
+            .json()
+            .map_err(|e| FeeFetcherError::Deserialize(e.to_string()))?;
+
+        Ok(estimates)
+    }
+}

--- a/crates/contracts/src/sdk/finance/option_offer/deposit.rs
+++ b/crates/contracts/src/sdk/finance/option_offer/deposit.rs
@@ -1,11 +1,12 @@
 use crate::error::TransactionBuildError;
 use crate::finance::option_offer::{OptionOfferArguments, get_option_offer_address};
+
+use crate::sdk::PartialPset;
 use crate::sdk::taproot_pubkey_gen::TaprootPubkeyGen;
 use crate::sdk::validation::TxOutExt;
 
-use simplicityhl::elements::bitcoin::secp256k1;
 use simplicityhl::elements::pset::{Input, Output, PartiallySignedTransaction};
-use simplicityhl::elements::{OutPoint, Script, TxOut};
+use simplicityhl::elements::{OutPoint, TxOut};
 use simplicityhl_core::SimplicityNetwork;
 
 /// Build PSET for user to deposit collateral and premium into the option offer covenant.
@@ -37,18 +38,13 @@ pub fn build_option_offer_deposit(
     premium_utxo: (OutPoint, TxOut),
     fee_utxo: (OutPoint, TxOut),
     collateral_deposit_amount: u64,
-    fee_amount: u64,
     arguments: &OptionOfferArguments,
     network: SimplicityNetwork,
-) -> Result<(PartiallySignedTransaction, TaprootPubkeyGen), TransactionBuildError> {
+) -> Result<(PartialPset, TaprootPubkeyGen), TransactionBuildError> {
     let (collateral_outpoint, collateral_tx_out) = collateral_utxo;
     let (premium_outpoint, premium_tx_out) = premium_utxo;
     let (fee_outpoint, fee_tx_out) = fee_utxo;
 
-    let (fee_asset_id, fee_change) = (
-        fee_tx_out.explicit_asset()?,
-        fee_tx_out.validate_amount(fee_amount)?,
-    );
     let (collateral_asset_id, total_collateral) = collateral_tx_out.explicit()?;
     let (premium_asset_id, total_premium) = premium_tx_out.explicit()?;
 
@@ -89,7 +85,7 @@ pub fn build_option_offer_deposit(
         });
     }
 
-    let change_recipient_script = collateral_tx_out.script_pubkey.clone();
+    let change_recipient_script = fee_tx_out.script_pubkey.clone();
 
     let option_offer_taproot_pubkey_gen =
         TaprootPubkeyGen::from(arguments, network, &get_option_offer_address)?;
@@ -110,7 +106,6 @@ pub fn build_option_offer_deposit(
 
     let is_collateral_change_needed = total_collateral != collateral_deposit_amount;
     let is_premium_change_needed = total_premium != premium_deposit_amount;
-    let is_fee_change_needed = fee_change != 0;
 
     pst.add_output(Output::new_explicit(
         option_offer_taproot_pubkey_gen.address.script_pubkey(),
@@ -144,26 +139,11 @@ pub fn build_option_offer_deposit(
         ));
     }
 
-    if is_fee_change_needed {
-        pst.add_output(Output::new_explicit(
-            change_recipient_script,
-            fee_change,
-            fee_asset_id,
-            None,
-        ));
-    }
+    let non_finalized_pset = PartialPset::new(
+        pst,
+        change_recipient_script,
+        vec![collateral_tx_out, premium_tx_out, fee_tx_out],
+    );
 
-    pst.add_output(Output::new_explicit(
-        Script::new(),
-        fee_amount,
-        fee_asset_id,
-        None,
-    ));
-
-    pst.extract_tx()?.verify_tx_amt_proofs(
-        secp256k1::SECP256K1,
-        &[collateral_tx_out, premium_tx_out, fee_tx_out],
-    )?;
-
-    Ok((pst, option_offer_taproot_pubkey_gen))
+    Ok((non_finalized_pset, option_offer_taproot_pubkey_gen))
 }

--- a/crates/contracts/src/sdk/finance/options/cancellation_option.rs
+++ b/crates/contracts/src/sdk/finance/options/cancellation_option.rs
@@ -2,9 +2,10 @@ use crate::finance::options::OptionsArguments;
 use crate::finance::options::build_witness::OptionBranch;
 
 use crate::error::TransactionBuildError;
+
+use crate::sdk::PartialPset;
 use crate::sdk::validation::TxOutExt;
 
-use simplicityhl::elements::bitcoin::secp256k1;
 use simplicityhl::elements::pset::{Input, Output, PartiallySignedTransaction};
 use simplicityhl::elements::{OutPoint, Script, Sequence, TxOut};
 
@@ -24,17 +25,12 @@ pub fn build_option_cancellation(
     fee_utxo: (OutPoint, TxOut),
     option_arguments: &OptionsArguments,
     amount_to_burn: u64,
-    fee_amount: u64,
-) -> Result<(PartiallySignedTransaction, OptionBranch), TransactionBuildError> {
+) -> Result<(PartialPset, OptionBranch), TransactionBuildError> {
     let (collateral_out_point, collateral_tx_out) = collateral_utxo;
     let (option_out_point, option_tx_out) = option_asset_utxo;
     let (grantor_out_point, grantor_tx_out) = grantor_asset_utxo;
     let (fee_out_point, fee_tx_out) = fee_utxo;
 
-    let (fee_asset_id, total_lbtc_left) = (
-        fee_tx_out.explicit_asset()?,
-        fee_tx_out.validate_amount(fee_amount)?,
-    );
     let (collateral_asset_id, total_collateral) = collateral_tx_out.explicit()?;
 
     let collateral_amount_to_withdraw = amount_to_burn * option_arguments.collateral_per_contract();
@@ -76,7 +72,6 @@ pub fn build_option_cancellation(
     let is_collateral_change_needed = total_collateral != collateral_amount_to_withdraw;
     let is_option_change_needed = total_option_token_amount != amount_to_burn;
     let is_grantor_change_needed = total_grantor_token_amount != amount_to_burn;
-    let is_lbtc_change_needed = total_lbtc_left != 0;
 
     if is_collateral_change_needed {
         pst.add_output(Output::new_explicit(
@@ -126,21 +121,11 @@ pub fn build_option_cancellation(
         ));
     }
 
-    if is_lbtc_change_needed {
-        pst.add_output(Output::new_explicit(
-            change_recipient_script,
-            total_lbtc_left,
-            fee_asset_id,
-            None,
-        ));
-    }
-
-    pst.add_output(Output::from_txout(TxOut::new_fee(fee_amount, fee_asset_id)));
-
-    pst.extract_tx()?.verify_tx_amt_proofs(
-        secp256k1::SECP256K1,
-        &[collateral_tx_out, option_tx_out, grantor_tx_out, fee_tx_out],
-    )?;
+    let non_finalized_pset = PartialPset::new(
+        pst,
+        change_recipient_script,
+        vec![collateral_tx_out, option_tx_out, grantor_tx_out, fee_tx_out],
+    );
 
     let option_branch = OptionBranch::Cancellation {
         is_change_needed: is_collateral_change_needed,
@@ -148,5 +133,5 @@ pub fn build_option_cancellation(
         collateral_amount_to_withdraw,
     };
 
-    Ok((pst, option_branch))
+    Ok((non_finalized_pset, option_branch))
 }

--- a/crates/contracts/src/sdk/finance/options/exercise_option.rs
+++ b/crates/contracts/src/sdk/finance/options/exercise_option.rs
@@ -3,9 +3,9 @@ use crate::finance::options::build_witness::OptionBranch;
 
 use crate::error::TransactionBuildError;
 
+use crate::sdk::PartialPset;
 use crate::sdk::validation::TxOutExt;
 
-use simplicityhl::elements::bitcoin::secp256k1;
 use simplicityhl::elements::pset::{Input, Output, PartiallySignedTransaction};
 use simplicityhl::elements::{LockTime, OutPoint, Script, Sequence, TxOut};
 
@@ -29,9 +29,8 @@ pub fn build_option_exercise(
     asset_utxo: (OutPoint, TxOut),
     fee_utxo: Option<(OutPoint, TxOut)>,
     amount_to_burn: u64,
-    fee_amount: u64,
     option_arguments: &OptionsArguments,
-) -> Result<(PartiallySignedTransaction, OptionBranch), TransactionBuildError> {
+) -> Result<(PartialPset, OptionBranch), TransactionBuildError> {
     let (collateral_out_point, collateral_tx_out) = collateral_utxo;
     let (option_out_point, option_tx_out) = option_asset_utxo;
     let (asset_out_point, asset_tx_out) = asset_utxo;
@@ -72,13 +71,8 @@ pub fn build_option_exercise(
     pst.add_input(asset_input);
 
     let has_separate_fee_utxo = fee_utxo.is_some();
-    let (change_recipient_script, fee_asset_id, total_lbtc_left, utxos_for_verification) =
+    let (change_recipient_script, utxos_for_verification) =
         if let Some((fee_out_point, fee_tx_out)) = fee_utxo {
-            let (fee_asset_id, total_lbtc_left) = (
-                fee_tx_out.explicit_asset()?,
-                fee_tx_out.validate_amount(fee_amount)?,
-            );
-
             if asset_amount_to_pay > total_asset_amount {
                 return Err(TransactionBuildError::InsufficientSettlementAsset {
                     required: asset_amount_to_pay,
@@ -95,12 +89,10 @@ pub fn build_option_exercise(
 
             (
                 change_recipient_script,
-                fee_asset_id,
-                total_lbtc_left,
                 vec![collateral_tx_out, option_tx_out, asset_tx_out, fee_tx_out],
             )
         } else {
-            let total_required = asset_amount_to_pay + fee_amount;
+            let total_required = asset_amount_to_pay;
             if total_required > total_asset_amount {
                 return Err(TransactionBuildError::InsufficientSettlementAsset {
                     required: total_required,
@@ -109,19 +101,15 @@ pub fn build_option_exercise(
             }
 
             let change_recipient_script = asset_tx_out.script_pubkey.clone();
-            let total_lbtc_left = total_asset_amount - asset_amount_to_pay - fee_amount;
 
             (
                 change_recipient_script,
-                settlement_asset_id,
-                total_lbtc_left,
                 vec![collateral_tx_out, option_tx_out, asset_tx_out],
             )
         };
 
     let is_collateral_change_needed = total_collateral != collateral_amount_to_get;
     let is_option_token_change_needed = total_option_token_amount != amount_to_burn;
-    let is_lbtc_change_needed = total_lbtc_left != 0;
 
     let is_asset_change_needed = has_separate_fee_utxo && total_asset_amount != asset_amount_to_pay;
 
@@ -166,34 +154,17 @@ pub fn build_option_exercise(
         ));
     }
 
-    if is_lbtc_change_needed {
-        pst.add_output(Output::new_explicit(
-            change_recipient_script.clone(),
-            total_lbtc_left,
-            fee_asset_id,
-            None,
-        ));
-    }
-
     pst.add_output(Output::new_explicit(
-        change_recipient_script,
+        change_recipient_script.clone(),
         collateral_amount_to_get,
         collateral_asset_id,
         None,
     ));
 
-    pst.add_output(Output::new_explicit(
-        Script::new(),
-        fee_amount,
-        fee_asset_id,
-        None,
-    ));
-
-    pst.extract_tx()?
-        .verify_tx_amt_proofs(secp256k1::SECP256K1, &utxos_for_verification)?;
+    let non_finalized_pset = PartialPset::new(pst, change_recipient_script, utxos_for_verification);
 
     Ok((
-        pst,
+        non_finalized_pset,
         OptionBranch::Exercise {
             is_change_needed: is_collateral_change_needed,
             amount_to_burn,

--- a/crates/contracts/src/sdk/finance/options/expiry_option.rs
+++ b/crates/contracts/src/sdk/finance/options/expiry_option.rs
@@ -3,9 +3,9 @@ use crate::finance::options::build_witness::OptionBranch;
 
 use crate::error::TransactionBuildError;
 
+use crate::sdk::PartialPset;
 use crate::sdk::validation::TxOutExt;
 
-use simplicityhl::elements::bitcoin::secp256k1;
 use simplicityhl::elements::pset::{Input, Output, PartiallySignedTransaction};
 use simplicityhl::elements::{LockTime, OutPoint, Script, Sequence, TxOut};
 
@@ -22,17 +22,12 @@ pub fn build_option_expiry(
     grantor_asset_utxo: (OutPoint, TxOut),
     fee_utxo: (OutPoint, TxOut),
     grantor_token_amount_to_burn: u64,
-    fee_amount: u64,
     option_arguments: &OptionsArguments,
-) -> Result<(PartiallySignedTransaction, OptionBranch), TransactionBuildError> {
+) -> Result<(PartialPset, OptionBranch), TransactionBuildError> {
     let (collateral_out_point, collateral_tx_out) = collateral_utxo;
     let (grantor_out_point, grantor_tx_out) = grantor_asset_utxo;
     let (fee_out_point, fee_tx_out) = fee_utxo;
 
-    let (fee_asset_id, total_lbtc_left) = (
-        fee_tx_out.explicit_asset()?,
-        fee_tx_out.validate_amount(fee_amount)?,
-    );
     let (collateral_asset_id, total_collateral) = collateral_tx_out.explicit()?;
     let (grantor_token_id, total_grantor_token_amount) = grantor_tx_out.explicit()?;
 
@@ -79,7 +74,6 @@ pub fn build_option_expiry(
 
     let is_collateral_change_needed = total_collateral != collateral_amount;
     let is_grantor_change_needed = total_grantor_token_amount != grantor_token_amount_to_burn;
-    let is_lbtc_change_needed = total_lbtc_left != 0;
 
     if is_collateral_change_needed {
         pst.add_output(Output::new_explicit(
@@ -113,26 +107,11 @@ pub fn build_option_expiry(
         ));
     }
 
-    if is_lbtc_change_needed {
-        pst.add_output(Output::new_explicit(
-            change_recipient_script,
-            total_lbtc_left,
-            fee_asset_id,
-            None,
-        ));
-    }
-
-    pst.add_output(Output::new_explicit(
-        Script::new(),
-        fee_amount,
-        fee_asset_id,
-        None,
-    ));
-
-    pst.extract_tx()?.verify_tx_amt_proofs(
-        secp256k1::SECP256K1,
-        &[collateral_tx_out, grantor_tx_out, fee_tx_out],
-    )?;
+    let non_finalized_pset = PartialPset::new(
+        pst,
+        change_recipient_script,
+        vec![collateral_tx_out, grantor_tx_out, fee_tx_out],
+    );
 
     let option_branch = OptionBranch::Expiry {
         is_change_needed: is_collateral_change_needed,
@@ -140,5 +119,5 @@ pub fn build_option_expiry(
         collateral_amount_to_withdraw: collateral_amount,
     };
 
-    Ok((pst, option_branch))
+    Ok((non_finalized_pset, option_branch))
 }

--- a/crates/contracts/src/sdk/finance/options/settlement_option.rs
+++ b/crates/contracts/src/sdk/finance/options/settlement_option.rs
@@ -3,9 +3,9 @@ use crate::finance::options::build_witness::OptionBranch;
 
 use crate::error::TransactionBuildError;
 
+use crate::sdk::PartialPset;
 use crate::sdk::validation::TxOutExt;
 
-use simplicityhl::elements::bitcoin::secp256k1;
 use simplicityhl::elements::pset::{Input, Output, PartiallySignedTransaction};
 use simplicityhl::elements::{LockTime, OutPoint, Script, Sequence, TxOut};
 
@@ -23,17 +23,12 @@ pub fn build_option_settlement(
     grantor_asset_utxo: (OutPoint, TxOut),
     fee_utxo: (OutPoint, TxOut),
     grantor_token_amount_to_burn: u64,
-    fee_amount: u64,
     option_arguments: &OptionsArguments,
-) -> Result<(PartiallySignedTransaction, OptionBranch), TransactionBuildError> {
+) -> Result<(PartialPset, OptionBranch), TransactionBuildError> {
     let (settlement_out_point, settlement_tx_out) = settlement_asset_utxo;
     let (grantor_out_point, grantor_tx_out) = grantor_asset_utxo;
     let (fee_out_point, fee_tx_out) = fee_utxo;
 
-    let (fee_asset_id, total_lbtc_left) = (
-        fee_tx_out.explicit_asset()?,
-        fee_tx_out.validate_amount(fee_amount)?,
-    );
     let (settlement_asset_id, available_settlement_asset) = settlement_tx_out.explicit()?;
     let (grantor_token_id, total_grantor_token_amount) = grantor_tx_out.explicit()?;
 
@@ -87,7 +82,6 @@ pub fn build_option_settlement(
 
     let is_settlement_change_needed = available_settlement_asset != asset_amount;
     let is_grantor_change_needed = total_grantor_token_amount != grantor_token_amount_to_burn;
-    let is_lbtc_change_needed = total_lbtc_left != 0;
 
     if is_settlement_change_needed {
         pst.add_output(Output::new_explicit(
@@ -121,26 +115,11 @@ pub fn build_option_settlement(
         ));
     }
 
-    if is_lbtc_change_needed {
-        pst.add_output(Output::new_explicit(
-            change_recipient_script,
-            total_lbtc_left,
-            fee_asset_id,
-            None,
-        ));
-    }
-
-    pst.add_output(Output::new_explicit(
-        Script::new(),
-        fee_amount,
-        fee_asset_id,
-        None,
-    ));
-
-    pst.extract_tx()?.verify_tx_amt_proofs(
-        secp256k1::SECP256K1,
-        &[settlement_tx_out, grantor_tx_out, fee_tx_out],
-    )?;
+    let non_finalized_pset = PartialPset::new(
+        pst,
+        change_recipient_script,
+        vec![settlement_tx_out, grantor_tx_out, fee_tx_out],
+    );
 
     let option_branch = OptionBranch::Settlement {
         is_change_needed: is_settlement_change_needed,
@@ -148,5 +127,5 @@ pub fn build_option_settlement(
         asset_amount,
     };
 
-    Ok((pst, option_branch))
+    Ok((non_finalized_pset, option_branch))
 }

--- a/crates/contracts/src/sdk/mod.rs
+++ b/crates/contracts/src/sdk/mod.rs
@@ -3,6 +3,10 @@ mod basic;
 #[cfg(any(feature = "finance-option-offer", feature = "finance-options"))]
 mod finance;
 
+mod fee_rate_fetcher;
+mod partial_pset;
+mod signer;
+
 pub mod taproot_pubkey_gen;
 pub mod validation;
 
@@ -10,3 +14,7 @@ pub mod validation;
 pub use basic::*;
 #[cfg(any(feature = "finance-option-offer", feature = "finance-options"))]
 pub use finance::*;
+
+pub use fee_rate_fetcher::*;
+pub use partial_pset::*;
+pub use signer::*;

--- a/crates/contracts/src/sdk/partial_pset.rs
+++ b/crates/contracts/src/sdk/partial_pset.rs
@@ -1,0 +1,415 @@
+use crate::error::TransactionBuildError;
+use crate::sdk::{SignerOnceTrait, SignerTrait};
+use simplicityhl::elements::bitcoin::secp256k1;
+use simplicityhl::elements::pset::{Output, PartiallySignedTransaction};
+use simplicityhl::elements::secp256k1_zkp::rand::thread_rng;
+use simplicityhl::elements::{AssetId, Script, Transaction};
+use simplicityhl::elements::{TxOut, TxOutSecrets};
+use simplicityhl_core::SimplicityNetwork;
+use std::collections::HashMap;
+
+/// Witness scale factor for weight-to-vsize conversion.
+/// In segwit, weight = 4 * `base_size` + `witness_size`, so vsize = weight / 4.
+pub const WITNESS_SCALE_FACTOR: usize = 4;
+
+/// Placeholder fee for first-pass weight measurement (1 satoshi).
+/// Used when building a transaction to measure its actual weight before
+/// calculating the real fee.
+pub const PLACEHOLDER_FEE: u64 = 1;
+
+#[derive(Debug, Clone, Copy)]
+struct PolicyAssetInfo {
+    input: u64,
+    output: u64,
+    policy_asset: AssetId,
+}
+
+#[derive(Debug, Clone)]
+pub struct PartialPset {
+    pset: PartiallySignedTransaction,
+    change_recipient_script: Script,
+    inp_tx_out_sec: Option<HashMap<usize, TxOutSecrets>>,
+    fee_amount: Option<u64>,
+    spent_tx_outs: Vec<TxOut>,
+    fee_rate: Option<f32>,
+}
+
+impl PartialPset {
+    #[must_use]
+    pub const fn new(
+        pset: PartiallySignedTransaction,
+        change_recipient_script: Script,
+        spent_tx_out: Vec<TxOut>,
+    ) -> Self {
+        Self {
+            pset,
+            change_recipient_script,
+            inp_tx_out_sec: None,
+            fee_amount: None,
+            spent_tx_outs: spent_tx_out,
+            fee_rate: None,
+        }
+    }
+
+    /// Sets input transaction output secrets for blinding purposes.
+    ///
+    /// # Arguments
+    ///
+    /// * `value` - A map of input indices to their corresponding `TxOutSecrets`
+    #[must_use]
+    pub(crate) fn inp_tx_out_secrets(mut self, value: HashMap<usize, TxOutSecrets>) -> Self {
+        self.inp_tx_out_sec = Some(value);
+        self
+    }
+
+    /// Sets a fixed fee amount for the transaction.
+    ///
+    /// # Arguments
+    ///
+    /// * `amount` - The fee amount in satoshis
+    #[must_use]
+    pub const fn fee(mut self, amount: u64) -> Self {
+        self.fee_amount = Some(amount);
+        self
+    }
+
+    /// Removes the currently set fee amount.
+    #[must_use]
+    pub const fn remove_fee(mut self) -> Self {
+        self.fee_amount = None;
+        self
+    }
+
+    /// Sets the fee rate for automatic fee calculation.
+    ///
+    /// # Arguments
+    ///
+    /// * `fee_rate` - Fee rate in satoshis per 1000 virtual bytes (sats/kvb)
+    #[must_use]
+    pub const fn fee_rate(mut self, fee_rate: f32) -> Self {
+        self.fee_rate = Some(fee_rate);
+        self
+    }
+
+    /// Removes the currently set fee rate.
+    #[must_use]
+    pub const fn remove_fee_rate(mut self) -> Self {
+        self.fee_rate = None;
+        self
+    }
+
+    /// Returns a copy of the internal partially signed transaction.
+    #[must_use]
+    pub fn pset(&self) -> PartiallySignedTransaction {
+        self.pset.clone()
+    }
+
+    /// Returns a copy of the change recipient script.
+    #[must_use]
+    pub fn change_recipient_script(&self) -> Script {
+        self.change_recipient_script.clone()
+    }
+
+    /// Returns a reference to the list of spent transaction outputs.
+    #[must_use]
+    pub fn get_spent_tx_outs(&self) -> &[TxOut] {
+        &self.spent_tx_outs
+    }
+
+    /// Returns a reference to the input transaction output secrets.
+    #[must_use]
+    pub fn get_inp_tx_out_sec(&self) -> &Option<HashMap<usize, TxOutSecrets>> {
+        &self.inp_tx_out_sec
+    }
+
+    /// Returns the currently set fee amount.
+    #[must_use]
+    pub fn get_fee(&self) -> Option<u64> {
+        self.fee_amount
+    }
+
+    /// Returns the currently set fee rate.
+    #[must_use]
+    pub fn get_fee_rate(&self) -> Option<f32> {
+        self.fee_rate
+    }
+
+    /// Calculates policy asset input and output amounts from the PSET.
+    /// Policy asset is derived from input.
+    #[must_use]
+    fn calculate_policy_asset_info(&self, network: SimplicityNetwork) -> PolicyAssetInfo {
+        let policy_asset = network.policy_asset();
+
+        let input = self.pset.inputs().iter().fold(0, |acc, x| {
+            if let Some(witness_utxo) = &x.witness_utxo
+                && let Some(witness_asset) = witness_utxo.asset.explicit()
+                && witness_asset == policy_asset
+                && let Some(amount) = witness_utxo.value.explicit()
+            {
+                acc + amount
+            } else {
+                acc
+            }
+        });
+        let output = self.pset.outputs().iter().fold(0, |acc, x| {
+            if let Some(asset) = x.asset
+                && asset == policy_asset
+                && let Some(amount) = x.amount
+            {
+                acc + amount
+            } else {
+                acc
+            }
+        });
+
+        PolicyAssetInfo {
+            input,
+            output,
+            policy_asset,
+        }
+    }
+
+    /// Creates a draft (blinded but unsigned) transaction for weight estimation or blinding factor extraction.
+    ///
+    /// This method creates a copy of the PSET, blinds it if secrets are available,
+    /// and extracts the transaction. Useful for:
+    /// - Extracting blinding factors before finalization
+    /// - Weight estimation for fee calculation
+    ///
+    /// # Arguments
+    ///
+    /// * `network` - The Simplicity network to use for deriving the policy asset
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TransactionBuildError`] if blinding or transaction extraction fails.
+    pub fn create_draft_pset(
+        &self,
+        network: SimplicityNetwork,
+    ) -> Result<PartiallySignedTransaction, TransactionBuildError> {
+        let temp_pset = self.pset.clone();
+        let policy_asset_info = self.calculate_policy_asset_info(network);
+
+        Self::insert_fees_raw(
+            temp_pset,
+            self.change_recipient_script.clone(),
+            policy_asset_info,
+            PLACEHOLDER_FEE,
+        )
+    }
+
+    /// Creates a PSET with fees inserted and outputs balanced.
+    ///
+    /// # Arguments
+    ///
+    /// * `fee` - The fee amount in satoshis to deduct from inputs
+    /// * `network` - The Simplicity network to use for deriving the policy asset
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TransactionBuildError`] if fee insertion or asset calculation fails.
+    pub fn create_pset(
+        &self,
+        fee: u64,
+        network: SimplicityNetwork,
+    ) -> Result<PartiallySignedTransaction, TransactionBuildError> {
+        let temp_pset = self.pset.clone();
+        let policy_asset_info = self.calculate_policy_asset_info(network);
+
+        Self::insert_fees_raw(
+            temp_pset,
+            self.change_recipient_script.clone(),
+            policy_asset_info,
+            fee,
+        )
+    }
+
+    /// Finalizes the partial PSET into a signed transaction via adding fees and running internal checks.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TransactionBuildError`] if inputs are insufficient, fee rate is missing,
+    ///     or signing/blinding/extraction fails.
+    #[allow(clippy::too_many_lines)]
+    pub fn finalize(
+        self,
+        network: SimplicityNetwork,
+        signer: impl SignerTrait,
+    ) -> Result<Transaction, TransactionBuildError> {
+        let policy_asset_info = self.calculate_policy_asset_info(network);
+        let fee = match self.fee_amount {
+            None => {
+                let temp_pset = self.pset.clone();
+                let temp_pset_with_fees = Self::insert_fees_raw(
+                    temp_pset,
+                    self.change_recipient_script.clone(),
+                    policy_asset_info,
+                    PLACEHOLDER_FEE,
+                )?;
+
+                let fee_rate = self.fee_rate.ok_or(TransactionBuildError::FeeRateIsEmpty)?;
+                let temp_finalized_pset = Self::finalize_pset_raw(
+                    temp_pset_with_fees,
+                    &self.inp_tx_out_sec,
+                    &self.spent_tx_outs,
+                )?;
+                let temp_tx = temp_finalized_pset.extract_tx()?;
+                let temp_signed_tx =
+                    Self::sign_tx_raw(temp_tx, &self.spent_tx_outs, network, signer.clone())?;
+                Self::calculate_fee_raw(&temp_signed_tx, fee_rate)?
+            }
+            Some(fee) => fee,
+        };
+
+        let pset_with_fees = Self::insert_fees_raw(
+            self.pset,
+            self.change_recipient_script,
+            policy_asset_info,
+            fee,
+        )?;
+        let finalized_pset =
+            Self::finalize_pset_raw(pset_with_fees, &self.inp_tx_out_sec, &self.spent_tx_outs)?;
+        let tx = finalized_pset.extract_tx()?;
+        let signed_tx = Self::sign_tx_raw(tx, &self.spent_tx_outs, network, signer)?;
+
+        Ok(signed_tx)
+    }
+
+    /// Inserts fees and change outputs into a PSET, balancing the policy asset.
+    ///
+    /// # Arguments
+    ///
+    /// * `pset` - The partially signed transaction to modify
+    /// * `change_recipient_script` - The script for receiving change
+    /// * `policy_asset_info` - Information about policy asset inputs and outputs
+    /// * `fee` - The fee amount to deduct
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TransactionBuildError::InsufficientAssetAmount`] if inputs are insufficient to cover outputs and fees.
+    fn insert_fees_raw(
+        mut pset: PartiallySignedTransaction,
+        change_recipient_script: Script,
+        policy_asset_info: PolicyAssetInfo,
+        fee: u64,
+    ) -> Result<PartiallySignedTransaction, TransactionBuildError> {
+        let PolicyAssetInfo {
+            input: policy_asset_in,
+            output: policy_asset_out,
+            policy_asset,
+        } = policy_asset_info;
+
+        if policy_asset_in < (policy_asset_out + fee) {
+            return Err(TransactionBuildError::InsufficientAssetAmount {
+                available: policy_asset_in,
+                has_to_be: policy_asset_out + fee,
+                asset_id: policy_asset,
+            });
+        }
+
+        let policy_change = policy_asset_in - policy_asset_out - fee;
+
+        if policy_change != 0 {
+            pset.add_output(Output::new_explicit(
+                change_recipient_script,
+                policy_change,
+                policy_asset,
+                None,
+            ));
+        }
+
+        pset.add_output(Output::from_txout(TxOut::new_fee(fee, policy_asset)));
+
+        Ok(pset)
+    }
+
+    /// Calculates the transaction fee from its weight and a given fee rate.
+    ///
+    /// # Arguments
+    ///
+    /// * `tx` - The transaction to calculate fee for
+    /// * `fee_rate` - Fee rate in satoshis per 1000 virtual bytes (sats/kvb)
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TransactionBuildError`] if weight calculation fails.
+    pub fn calculate_fee_raw(
+        tx: &Transaction,
+        fee_rate: f32,
+    ) -> Result<u64, TransactionBuildError> {
+        let weight = tx.discount_weight();
+        let fee = weight_to_sats_fee(weight, fee_rate);
+        Ok(fee)
+    }
+
+    /// Signs a transaction using the provided signer implementation.
+    ///
+    /// # Arguments
+    ///
+    /// * `tx` - The transaction to sign
+    /// * `spent_tx_outs` - The outputs being spent by this transaction
+    /// * `network` - The Simplicity network for signing context
+    /// * `signer` - A one-time signer implementation
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TransactionBuildError`] if signing fails.
+    pub fn sign_tx_raw(
+        tx: Transaction,
+        spent_tx_outs: &[TxOut],
+        network: SimplicityNetwork,
+        signer: impl SignerOnceTrait,
+    ) -> Result<Transaction, TransactionBuildError> {
+        let tx = signer(network, tx, spent_tx_outs).map_err(TransactionBuildError::PsetSign)?;
+        Ok(tx)
+    }
+
+    /// Finalizes a PSET by blinding and verifying proof constraints.
+    ///
+    /// # Arguments
+    ///
+    /// * `pset` - The partially signed transaction to finalize
+    /// * `inp_tx_out_sec` - Optional input secrets for blinding
+    /// * `spent_tx_outs` - The outputs being spent by this transaction
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TransactionBuildError`] if blinding, extraction, or proof verification fails.
+    pub fn finalize_pset_raw(
+        mut pset: PartiallySignedTransaction,
+        inp_tx_out_sec: &Option<HashMap<usize, TxOutSecrets>>,
+        spent_tx_outs: &[TxOut],
+    ) -> Result<PartiallySignedTransaction, TransactionBuildError> {
+        if let Some(inp_tx_out_sec) = &inp_tx_out_sec {
+            pset.blind_last(&mut thread_rng(), secp256k1::SECP256K1, inp_tx_out_sec)?;
+        }
+
+        pset.extract_tx()?
+            .verify_tx_amt_proofs(secp256k1::SECP256K1, spent_tx_outs)?;
+        Ok(pset)
+    }
+}
+
+/// Calculate fee from weight and fee rate (sats/kvb).
+///
+/// Formula: `fee = ceil(vsize * fee_rate / 1000)`
+/// where `vsize = ceil(weight / 4)`
+///
+/// # Arguments
+///
+/// * `weight` - Transaction weight in weight units (WU)
+/// * `fee_rate` - Fee rate in satoshis per 1000 virtual bytes (sats/kvb)
+///
+/// # Returns
+///
+/// The calculated fee in satoshis.
+#[must_use]
+#[allow(
+    clippy::cast_precision_loss,
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss
+)]
+pub fn weight_to_sats_fee(weight: usize, fee_rate: f32) -> u64 {
+    let vsize = weight.div_ceil(WITNESS_SCALE_FACTOR);
+    (vsize as f32 * fee_rate / 1000.0).ceil() as u64
+}

--- a/crates/contracts/src/sdk/signer.rs
+++ b/crates/contracts/src/sdk/signer.rs
@@ -1,0 +1,109 @@
+use simplicityhl::elements::bitcoin::secp256k1;
+use simplicityhl::elements::secp256k1_zkp::SecretKey;
+use simplicityhl::elements::{Transaction, TxOut};
+use simplicityhl::tracker::TrackerLogLevel;
+use simplicityhl_core::{
+    SimplicityNetwork, create_p2pk_signature, create_p2tr_address, finalize_p2pk_transaction,
+    get_p2pk_program,
+};
+
+pub trait SignerTrait:
+    Fn(
+        SimplicityNetwork,
+        Transaction,
+        &[TxOut],
+    ) -> Result<Transaction, simplicityhl_core::ProgramError>
+    + Clone
+{
+}
+
+impl<T> SignerTrait for T where
+    T: Fn(
+            SimplicityNetwork,
+            Transaction,
+            &[TxOut],
+        ) -> Result<Transaction, simplicityhl_core::ProgramError>
+        + Clone
+{
+}
+
+pub trait SignerOnceTrait:
+    FnOnce(
+    SimplicityNetwork,
+    Transaction,
+    &[TxOut],
+) -> Result<Transaction, simplicityhl_core::ProgramError>
+{
+}
+
+impl<T> SignerOnceTrait for T where
+    T: FnOnce(
+        SimplicityNetwork,
+        Transaction,
+        &[TxOut],
+    ) -> Result<Transaction, simplicityhl_core::ProgramError>
+{
+}
+
+pub struct DummySigner;
+
+impl DummySigner {
+    #[allow(unused)]
+    const DUMMY_SECRET_KEY: [u8; 32] = [1; 32];
+
+    /// Get the dummy keypair used for fee estimation.
+    /// This keypair is deterministic and used only to produce valid transaction structures.
+    #[allow(unused)]
+    fn get_dummy_keypair() -> secp256k1::Keypair {
+        secp256k1::Keypair::from_secret_key(
+            secp256k1::SECP256K1,
+            &SecretKey::from_slice(&Self::DUMMY_SECRET_KEY).expect("valid secret key"),
+        )
+    }
+
+    /// Returns a closure that signs a transaction with dummy signatures.
+    ///
+    /// This is used for fee estimation - the transaction needs valid witness data
+    /// to calculate accurate weight/fees, but the actual signatures don't need
+    /// to be cryptographically valid for spending (they just need to be the right size).
+    #[allow(clippy::type_complexity, unused)]
+    pub(crate) fn get_signer_closure() -> impl SignerTrait {
+        |network: SimplicityNetwork, tx: Transaction, utxos: &[TxOut]| {
+            let keypair = Self::get_dummy_keypair();
+            let x_only_public_key = keypair.x_only_public_key().0;
+            let p2pk_program = get_p2pk_program(&x_only_public_key)?;
+            let cmr = p2pk_program.commit().cmr();
+
+            let dummy_address =
+                create_p2tr_address(cmr, &x_only_public_key, network.address_params());
+            let dummy_script_pubkey = dummy_address.script_pubkey();
+
+            let dummy_utxos: Vec<TxOut> = utxos
+                .iter()
+                .map(|utxo: &TxOut| TxOut {
+                    script_pubkey: dummy_script_pubkey.clone(),
+                    ..utxo.clone()
+                })
+                .collect();
+
+            let mut signed_tx = tx;
+
+            for i in 0..signed_tx.input.len() {
+                let signature =
+                    create_p2pk_signature(&signed_tx, &dummy_utxos, &keypair, i, network)?;
+
+                signed_tx = finalize_p2pk_transaction(
+                    signed_tx,
+                    &dummy_utxos,
+                    &x_only_public_key,
+                    &signature,
+                    i,
+                    network,
+                    TrackerLogLevel::None,
+                )?;
+            }
+
+            Ok(signed_tx)
+        }
+    }
+}


### PR DESCRIPTION
Add `PartialPset` usage and finalization step:
* use signer implmentation from pr https://github.com/BlockstreamResearch/simplicity-contracts/pull/58
* use fee rate fetcher from pr https://github.com/BlockstreamResearch/simplicity-contracts/pull/60
* use partial pset from https://github.com/BlockstreamResearch/simplicity-contracts/pull/61
* adapt code due to usage of finalization step instead of manual tx creation
* adapt funding step to new changes
* fix tests which was failling