### PR TITLE
:sparkles: Additional protection against a second preimage attack

### DIFF
--- a/crates/contracts/src/state_management/smt_storage/build_witness.rs
+++ b/crates/contracts/src/state_management/smt_storage/build_witness.rs
@@ -14,6 +14,32 @@ pub type u256 = [u8; 32];
 /// and cannot dynamically resolve array lengths using `param::LEN`.
 pub const DEPTH: usize = 8;
 
+/// Precomputed SHA256 midstate for the `SMT/1.0/leaf` domain separation tag.
+///
+/// This is the result of double-hashing `b"SMT/1.0/leaf"` into a fresh SHA256 engine,
+/// stored in reversed byte order as required by [`sha256::Midstate`].
+/// 
+/// The `1.0` denotes the protocol version, allowing future SMT upgrades to safely
+/// alter hashing logic without risking backward-compatibility hash collisions.
+#[rustfmt::skip]
+pub const LEAF_MIDSTATE: [u8; 32] = [
+    0x64, 0x59, 0x25, 0x75, 0x94, 0x38, 0xdd, 0x53, 0xbc, 0x61, 0x54, 0x2a, 0x12, 0x77, 0x85, 0x3e,
+    0x62, 0x7e, 0x14, 0x80, 0xd7, 0xad, 0xf0, 0x5b, 0x78, 0x09, 0x93, 0x62, 0x70, 0x98, 0x24, 0xbf,
+];
+
+/// Precomputed SHA256 midstate for the `SMT/1.0/node` domain separation tag.
+///
+/// This is the result of double-hashing `b"SMT/1.0/node"` into a fresh SHA256 engine,
+/// stored in reversed byte order as required by [`sha256::Midstate`].
+///
+/// The `1.0` denotes the protocol version, allowing future SMT upgrades to safely
+/// alter hashing logic without risking backward-compatibility hash collisions
+#[rustfmt::skip]
+pub const NODE_MIDSTATE: [u8; 32] = [
+    0xe3, 0x4c, 0x71, 0xa4, 0x67, 0x56, 0x64, 0xaa, 0x91, 0x98, 0x37, 0x94, 0xe6, 0x30, 0x0c, 0xa0,
+    0xe2, 0x0d, 0xbb, 0xb2, 0xe6, 0x69, 0x03, 0x3f, 0x2b, 0x10, 0x20, 0xc9, 0x68, 0x55, 0x06, 0xe6,
+];
+
 #[derive(Debug, Clone, bincode::Encode, bincode::Decode, PartialEq, Eq)]
 pub struct SMTWitness {
     /// The internal public key used for Taproot tweaking.

--- a/crates/contracts/src/state_management/smt_storage/mod.rs
+++ b/crates/contracts/src/state_management/smt_storage/mod.rs
@@ -13,14 +13,17 @@ use simplicityhl::simplicity::jet::elements::{ElementsEnv, ElementsUtxo};
 use simplicityhl::simplicity::{Cmr, RedeemNode};
 use simplicityhl::tracker::TrackerLogLevel;
 use simplicityhl::{Arguments, CompiledProgram, TemplateProgram};
+use wallet_abi::simplicity_leaf_version;
 use wallet_abi::{Network, ProgramError, run_program};
-use wallet_abi::{simplicity_leaf_version, tap_data_hash};
 
 mod build_witness;
 mod smt;
 
 pub use build_witness::{DEPTH, SMTWitness, build_smt_storage_witness, u256};
 pub use smt::SparseMerkleTree;
+
+use crate::smt_storage::build_witness::LEAF_MIDSTATE;
+use crate::smt_storage::build_witness::NODE_MIDSTATE;
 
 #[must_use]
 pub fn get_path_bits(path: &[bool], reverse: bool) -> u8 {
@@ -91,6 +94,24 @@ pub fn control_block(cmr: Cmr, spend_info: &TaprootSpendInfo) -> ControlBlock {
         .expect("must get control block")
 }
 
+/// Create a SHA256 context, initialized with a specific `LEAF_TAG` constant and data
+///
+/// Based on the C implementation of the `tapdata_init` jet:
+/// <https://github.com/BlockstreamResearch/simplicity/blob/d190505509f4c04b1b9193c6739515f9faa18aac/C/jets.c#L1408>
+#[must_use]
+pub fn tap_leaf_hash(data: &[u8]) -> sha256::Hash {
+    let mut eng =
+        sha256::HashEngine::from_midstate(sha256::Midstate::from_byte_array(LEAF_MIDSTATE), 64);
+    eng.input(data);
+    sha256::Hash::from_engine(eng)
+}
+
+/// Returns a pre-initialized SHA256 engine with the double `NODE_TAG` already processed.
+#[must_use]
+pub fn node_hash_engine() -> sha256::HashEngine {
+    sha256::HashEngine::from_midstate(sha256::Midstate::from_byte_array(NODE_MIDSTATE), 64)
+}
+
 /// Computes the TapData-tagged hash of the Simplicity state (SMT Root).
 ///
 /// This involves hashing the tag "`TapData`" twice, followed by the leaf value
@@ -98,13 +119,17 @@ pub fn control_block(cmr: Cmr, spend_info: &TaprootSpendInfo) -> ControlBlock {
 ///
 /// # Security Note: Second Preimage Resistance
 ///
-/// The `raw_path` (bit representation of the path) is included in the initial hash of the leaf
-/// alongside the `leaf` data.
+/// This implementation employs a dual-layered defense mechanism against **second
+/// preimage attacks** (specifically, Merkle substitution attacks) using explicit
+/// domain separation and path binding:
 ///
-/// This is a defense mechanism against **second preimage attacks** (specifically, Merkle substitution attacks).
-/// In Merkle trees (especially those with variable depth), an attacker might try to present
-/// an internal node as a leaf, or vice versa. By including the path in the leaf's hash,
-/// we strictly bind the data to its specific position in the tree hierarchy.
+/// 1. **Domain Separation (`LEAF_TAG` vs `NODE_TAG`)**: An attacker might try to present
+///    an internal node as a leaf, or vice versa. By utilizing distinct tags for leaves
+///    and branches, the tree guarantees that a branch hash can never be mathematically
+///    parsed as a leaf hash.
+/// 2. **Path Binding**: The `raw_path` (bit representation of the path) is included
+///    in the initial hash of the leaf alongside the `leaf` data. This strictly binds
+///    the data to its exact position in the tree hierarchy.
 ///
 /// Although `DEPTH` is currently fixed (which mitigates some of these risks naturally),
 /// this explicit domain separation ensures that a valid proof for a leaf at one position
@@ -125,10 +150,10 @@ pub fn compute_tapdata_tagged_hash_of_the_state(
     let mut tapdata_input = Vec::with_capacity(leaf.len() + 1);
     tapdata_input.extend_from_slice(leaf);
     tapdata_input.push(get_path_bits(&raw_path, false));
-    let mut current_hash = tap_data_hash(&tapdata_input);
+    let mut current_hash = tap_leaf_hash(&tapdata_input);
 
     for (hash, is_right_direction) in path {
-        let mut eng = sha256::Hash::engine();
+        let mut eng = node_hash_engine();
 
         if *is_right_direction {
             eng.input(hash);
@@ -277,6 +302,7 @@ pub fn finalize_get_storage_transaction(
 #[cfg(test)]
 mod smt_storage_tests {
     use super::*;
+
     use anyhow::Result;
     use simplicityhl::elements::secp256k1_zkp::rand::{Rng, thread_rng};
     use std::sync::Arc;
@@ -309,6 +335,35 @@ mod smt_storage_tests {
 		    0x07, 0x8a, 0x5a, 0x0f, 0x28, 0xec, 0x96, 0xd5, 0x47, 0xbf, 0xee, 0x9a, 0xce, 0x80, 0x3a, 0xc0, 
 	    ])
         .expect("key should be valid")
+    }
+
+    #[test]
+    fn tap_leaf_midstate() {
+        let leaf_tag = b"SMT/1.0/leaf";
+        let tag = sha256::Hash::hash(leaf_tag);
+
+        let mut eng = sha256::Hash::engine();
+        eng.input(tag.as_byte_array());
+        eng.input(tag.as_byte_array());
+        dbg!(eng.midstate());
+        assert_eq!(
+            eng.midstate(),
+            sha256::Midstate::from_byte_array(LEAF_MIDSTATE)
+        );
+    }
+
+    #[test]
+    fn node_midstate() {
+        let node_tag = b"SMT/1.0/node";
+        let tag = sha256::Hash::hash(node_tag);
+
+        let mut eng = sha256::Hash::engine();
+        eng.input(tag.as_byte_array());
+        eng.input(tag.as_byte_array());
+        assert_eq!(
+            eng.midstate(),
+            sha256::Midstate::from_byte_array(NODE_MIDSTATE)
+        );
     }
 
     #[test]

--- a/crates/contracts/src/state_management/smt_storage/smt.rs
+++ b/crates/contracts/src/state_management/smt_storage/smt.rs
@@ -1,7 +1,7 @@
 use simplicityhl::simplicity::elements::hashes::HashEngine as _;
 use simplicityhl::simplicity::hashes::{Hash, sha256};
-use wallet_abi::tap_data_hash;
 
+use crate::smt_storage::{node_hash_engine, tap_leaf_hash};
 use crate::state_management::smt_storage::get_path_bits;
 
 use super::build_witness::{DEPTH, u256};
@@ -70,7 +70,7 @@ impl TreeNode {
 ///      at a higher level. Even if the data matches, the path/position will differ, changing the hash.
 ///
 /// 2. **Domain Separation**:
-///    The function initializes with `Hash(b"TapData")`.
+///    The function initializes with `Hash(LEAF_TAG)`, where `LEAF_TAG` is an internal constant.
 ///    * *Why?* This ensures that hashes generated for this SMT state cannot be confused with other
 ///      Bitcoin/Elements hashes (like `TapLeaf` or `TapBranch` hashes), preventing cross-context collisions.
 ///
@@ -93,13 +93,12 @@ impl SparseMerkleTree {
     #[must_use]
     pub fn new() -> Self {
         let mut precalculate_hashes = [[0u8; 32]; DEPTH];
-        let mut eng = sha256::Hash::engine();
         let zero = [0u8; 32];
-        eng.input(&zero);
-        precalculate_hashes[0] = *sha256::Hash::from_engine(eng).as_byte_array();
+        precalculate_hashes[0] = *tap_leaf_hash(&zero).as_byte_array();
 
         for i in 1..DEPTH {
-            let mut eng = sha256::Hash::engine();
+            let mut eng = node_hash_engine();
+
             eng.input(&precalculate_hashes[i - 1]);
             eng.input(&precalculate_hashes[i - 1]);
             precalculate_hashes[i] = *sha256::Hash::from_engine(eng).as_byte_array();
@@ -113,11 +112,13 @@ impl SparseMerkleTree {
         }
     }
 
-    /// Computes parent hash: `SHA256(left_child_hash || right_child_hash)`.
+    /// Computes parent hash using the globally cached double-tag midstate.
     fn calculate_hash(left: &TreeNode, right: &TreeNode) -> u256 {
-        let mut eng = sha256::Hash::engine();
+        let mut eng = node_hash_engine();
+
         eng.input(&left.get_hash());
         eng.input(&right.get_hash());
+
         *sha256::Hash::from_engine(eng).as_byte_array()
     }
 
@@ -138,7 +139,7 @@ impl SparseMerkleTree {
             let mut tapdata_input = Vec::with_capacity(leaf.len() + 1);
             tapdata_input.extend_from_slice(leaf);
             tapdata_input.push(get_path_bits(path, true));
-            let leaf_hash = tap_data_hash(&tapdata_input);
+            let leaf_hash = tap_leaf_hash(&tapdata_input);
             **root = TreeNode::Leaf {
                 leaf_hash: *leaf_hash.as_byte_array(),
             };

--- a/crates/contracts/src/state_management/smt_storage/source_simf/smt_storage.simf
+++ b/crates/contracts/src/state_management/smt_storage/source_simf/smt_storage.simf
@@ -4,9 +4,10 @@
  * than Merkle Trees. By avoiding proof overhead like sibling hashes, we reduce 
  * witness size and simplify contract logic for small N.
  */
-fn hash_array_tr_storage_with_update(elem: (u256, bool), prev_hash: u256) -> u256 {
+fn hash_array_tr_storage_with_update(elem: (u256, bool), prev_hash_ctx: (u256, Ctx8)) -> (u256, Ctx8) {
     let (hash, is_right): (u256, bool) = dbg!(elem);
-    let ctx: Ctx8 = jet::sha_256_ctx_8_init();
+    let (prev_hash, ctx_node): (u256, Ctx8) = prev_hash_ctx;
+    let ctx: Ctx8 = ctx_node;
 
     let new_hash: Ctx8 = match is_right {
         true => {
@@ -19,18 +20,48 @@ fn hash_array_tr_storage_with_update(elem: (u256, bool), prev_hash: u256) -> u25
         }
     };
 
-    jet::sha_256_ctx_8_finalize(new_hash)
+    (jet::sha_256_ctx_8_finalize(new_hash), ctx_node)
+}
+
+// Use tag: SMT/1.0/leaf
+fn tapleaf_init() -> Ctx8 {
+    let doubled_tag_hash: [u8; 64] = [
+        0xb6, 0xc5, 0x7e, 0x7a, 0xa0, 0x8c, 0xd9, 0xe8, 0xc2, 0xfb, 0x65, 0xee, 0x31, 0x6d, 0x2f, 0xd9,
+        0xa2, 0x4b, 0xf4, 0xf4, 0x00, 0xc8, 0x6d, 0xe5, 0x5d, 0xcd, 0x8c, 0x4d, 0x38, 0x3d, 0x99, 0xd8,
+        0xb6, 0xc5, 0x7e, 0x7a, 0xa0, 0x8c, 0xd9, 0xe8, 0xc2, 0xfb, 0x65, 0xee, 0x31, 0x6d, 0x2f, 0xd9,
+        0xa2, 0x4b, 0xf4, 0xf4, 0x00, 0xc8, 0x6d, 0xe5, 0x5d, 0xcd, 0x8c, 0x4d, 0x38, 0x3d, 0x99, 0xd8,
+    ];
+
+    let ctx: Ctx8 = jet::sha_256_ctx_8_init();
+    jet::sha_256_ctx_8_add_64(ctx, doubled_tag_hash)
+}
+
+// Use tag: SMT/1.0/node
+fn tapnode_init() -> Ctx8 {
+    let doubled_tag_hash: [u8; 64] = [
+        0x1f, 0xa6, 0xe8, 0x92, 0x6a, 0x5f, 0x09, 0xa8, 0xf7, 0xb2, 0xe1, 0x57, 0x86, 0x68, 0x2f, 0xaa,
+        0xdc, 0xac, 0xee, 0x90, 0x95, 0x2f, 0xe4, 0x61, 0x28, 0x5c, 0x77, 0x8c, 0xb9, 0x5e, 0xb7, 0xb2,
+        0x1f, 0xa6, 0xe8, 0x92, 0x6a, 0x5f, 0x09, 0xa8, 0xf7, 0xb2, 0xe1, 0x57, 0x86, 0x68, 0x2f, 0xaa,
+        0xdc, 0xac, 0xee, 0x90, 0x95, 0x2f, 0xe4, 0x61, 0x28, 0x5c, 0x77, 0x8c, 0xb9, 0x5e, 0xb7, 0xb2,
+    ];
+
+    let ctx: Ctx8 = jet::sha_256_ctx_8_init();
+    jet::sha_256_ctx_8_add_64(ctx, doubled_tag_hash)
 }
 
 fn script_hash_for_input_script(key: u256, leaf: u256, path_bits: u8, merkle_data: [(u256, bool); 8]) -> u256 {
     let tap_leaf: u256 = jet::tapleaf_hash();
-    let ctx: Ctx8 = jet::tapdata_init();
+    let ctx: Ctx8 = tapleaf_init();
     let ctx: Ctx8 = jet::sha_256_ctx_8_add_32(ctx, leaf);
     let ctx: Ctx8 = jet::sha_256_ctx_8_add_1(ctx, path_bits);
 
     let hash_leaf: u256 = jet::sha_256_ctx_8_finalize(ctx);
 
-    let computed: u256 = array_fold::<hash_array_tr_storage_with_update, 8>(merkle_data, hash_leaf);
+    // Optimize node tag calculation
+    let ctx_node: Ctx8 = tapnode_init();
+    let (computed, _): (u256, Ctx8) = array_fold::<hash_array_tr_storage_with_update, 8>(
+        merkle_data, (hash_leaf, ctx_node)
+    );
     let tap_node: u256 = jet::build_tapbranch(tap_leaf, computed);
 
     let tweaked_key: u256 = jet::build_taptweak(key, tap_node);


### PR DESCRIPTION
The comments from PR #49 have been addressed.

**Mitigated Second Preimage Attacks:** Introduced proper domain separation for internal hashes to ensure the structure is fully protected.

**Hardcoded Unique Tags:** Passed hardcoded application-specific tags (`SMT/1.0/leaf` and `SMT/1.0/node`) directly into the script, replacing the reused TapData tag.