### PR TITLE
general: bump simplex to 0.0.6

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,5 @@
+[target.aarch64-apple-darwin]
+linker = "/usr/bin/cc"
+
+[target.x86_64-apple-darwin]
+linker = "/usr/bin/cc"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,7 +30,7 @@ jobs:
           export SIMPLEX_DIR="$HOME/.simplex"
           curl -L https://raw.githubusercontent.com/BlockstreamResearch/smplx/master/simplexup/install | bash
           echo "$SIMPLEX_DIR/bin" >> "$GITHUB_PATH"
-          "$SIMPLEX_DIR/bin/simplexup" --install v0.0.4 --platform linux --arch amd64
+          "$SIMPLEX_DIR/bin/simplexup" --install v0.0.6 --platform linux --arch amd64
 
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,7 +33,7 @@ jobs:
           export SIMPLEX_DIR="$HOME/.simplex"
           curl -L https://raw.githubusercontent.com/BlockstreamResearch/smplx/master/simplexup/install | bash
           echo "$SIMPLEX_DIR/bin" >> "$GITHUB_PATH"
-          "$SIMPLEX_DIR/bin/simplexup" --install v0.0.4 --platform linux --arch amd64
+          "$SIMPLEX_DIR/bin/simplexup" --install v0.0.6 --platform linux --arch amd64
 
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
@@ -68,7 +68,7 @@ jobs:
           export SIMPLEX_DIR="$HOME/.simplex"
           curl -L https://raw.githubusercontent.com/BlockstreamResearch/smplx/master/simplexup/install | bash
           echo "$SIMPLEX_DIR/bin" >> "$GITHUB_PATH"
-          "$SIMPLEX_DIR/bin/simplexup" --install v0.0.4 --platform linux --arch amd64
+          "$SIMPLEX_DIR/bin/simplexup" --install v0.0.6 --platform linux --arch amd64
 
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1340,8 +1340,8 @@ dependencies = [
 
 [[package]]
 name = "smplx-build"
-version = "0.0.4"
-source = "git+https://github.com/BlockstreamResearch/smplx?branch=dev#3330f15249234ab91e3243443de81fc1a5b19ae7"
+version = "0.0.6"
+source = "git+https://github.com/BlockstreamResearch/smplx?branch=dev#1c0ca5fc0de828c6bc9c35a6a26a8b86d48ffaf4"
 dependencies = [
  "glob",
  "globwalk",
@@ -1358,8 +1358,8 @@ dependencies = [
 
 [[package]]
 name = "smplx-macros"
-version = "0.0.4"
-source = "git+https://github.com/BlockstreamResearch/smplx?branch=dev#3330f15249234ab91e3243443de81fc1a5b19ae7"
+version = "0.0.6"
+source = "git+https://github.com/BlockstreamResearch/smplx?branch=dev#1c0ca5fc0de828c6bc9c35a6a26a8b86d48ffaf4"
 dependencies = [
  "smplx-build",
  "smplx-test",
@@ -1368,8 +1368,8 @@ dependencies = [
 
 [[package]]
 name = "smplx-regtest"
-version = "0.0.4"
-source = "git+https://github.com/BlockstreamResearch/smplx?branch=dev#3330f15249234ab91e3243443de81fc1a5b19ae7"
+version = "0.0.6"
+source = "git+https://github.com/BlockstreamResearch/smplx?branch=dev#1c0ca5fc0de828c6bc9c35a6a26a8b86d48ffaf4"
 dependencies = [
  "electrsd",
  "hex",
@@ -1383,8 +1383,8 @@ dependencies = [
 
 [[package]]
 name = "smplx-sdk"
-version = "0.0.4"
-source = "git+https://github.com/BlockstreamResearch/smplx?branch=dev#3330f15249234ab91e3243443de81fc1a5b19ae7"
+version = "0.0.6"
+source = "git+https://github.com/BlockstreamResearch/smplx?branch=dev#1c0ca5fc0de828c6bc9c35a6a26a8b86d48ffaf4"
 dependencies = [
  "bip39",
  "bitcoin_hashes",
@@ -1402,8 +1402,8 @@ dependencies = [
 
 [[package]]
 name = "smplx-std"
-version = "0.0.4"
-source = "git+https://github.com/BlockstreamResearch/smplx?branch=dev#3330f15249234ab91e3243443de81fc1a5b19ae7"
+version = "0.0.6"
+source = "git+https://github.com/BlockstreamResearch/smplx?branch=dev#1c0ca5fc0de828c6bc9c35a6a26a8b86d48ffaf4"
 dependencies = [
  "either",
  "serde",
@@ -1415,8 +1415,8 @@ dependencies = [
 
 [[package]]
 name = "smplx-test"
-version = "0.0.4"
-source = "git+https://github.com/BlockstreamResearch/smplx?branch=dev#3330f15249234ab91e3243443de81fc1a5b19ae7"
+version = "0.0.6"
+source = "git+https://github.com/BlockstreamResearch/smplx?branch=dev#1c0ca5fc0de828c6bc9c35a6a26a8b86d48ffaf4"
 dependencies = [
  "electrsd",
  "proc-macro2",

--- a/Simplex.toml
+++ b/Simplex.toml
@@ -2,3 +2,6 @@
 src_dir = "crates/contracts/simf"
 simf_files = ["**/*.simf"]
 out_dir = "crates/contracts/src/artifacts"
+
+[test]
+verbosity = "Debug"

--- a/crates/contracts/src/programs/option_offer.rs
+++ b/crates/contracts/src/programs/option_offer.rs
@@ -72,7 +72,7 @@ impl OptionOffer {
     ) -> Self {
         Self {
             program: OptionOfferProgram::new(OptionOfferArguments::from(parameters))
-                .with_pub_key(internal_key),
+                .with_taproot_pubkey(internal_key),
             parameters,
         }
     }

--- a/crates/contracts/src/programs/options.rs
+++ b/crates/contracts/src/programs/options.rs
@@ -115,7 +115,7 @@ impl Options {
     pub fn from_internal_key(internal_key: XOnlyPublicKey, parameters: OptionsParameters) -> Self {
         Self {
             program: OptionsProgram::new(OptionsArguments::from(parameters))
-                .with_pub_key(internal_key),
+                .with_taproot_pubkey(internal_key),
             parameters,
         }
     }


### PR DESCRIPTION
.cargo/config.toml: pinned macOS linking to /usr/bin/cc to avoid the Nix clang -liconv linker failure